### PR TITLE
Increases name length of symbol name to 128

### DIFF
--- a/source/amx/amx.h
+++ b/source/amx/amx.h
@@ -233,7 +233,7 @@ typedef struct tagAMX_NATIVE_INFO {
 #define AMX_USERNUM     4
 #endif
 #define sEXPMAX         19      /* maximum name length for file version <= 6 */
-#define sNAMEMAX        31      /* maximum name length of symbol name */
+#define sNAMEMAX        127     /* maximum name length of symbol name */
 
 typedef struct tagAMX_FUNCSTUB {
   ucell address         PACKED;


### PR DESCRIPTION
- [Related to SA-MP forum suggestion](http://forum.sa-mp.com/showthread.php?t=545838)
- [Suggested by Y_Less](http://forum.sa-mp.com/showpost.php?p=3253654&postcount=3)

Having only 32 characters is really a pain in the butt, having 128 as maximum I think it would be way better.
