### PR TITLE
Remove Linux crash lines (#64, #114)

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2074,6 +2074,8 @@ static int nesting=0;
          */
       } else {
         arglist[argpos]=ARG_DONE; /* flag argument as "present" */
+        if (arg[argidx].ident!=0 && arg[argidx].numtags==1)
+          lval.cmptag=arg[argidx].tags[0];  /* set the expected tag, if any */
         lvalue=hier14(&lval);
         assert(sc_status==statFIRST || arg[argidx].ident== 0 || arg[argidx].tags!=NULL);
         switch (arg[argidx].ident) {

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2074,8 +2074,6 @@ static int nesting=0;
          */
       } else {
         arglist[argpos]=ARG_DONE; /* flag argument as "present" */
-        if (arg[argidx].numtags==1)     /* set the expected tag, if any */
-          lval.cmptag=arg[argidx].tags[0];
         lvalue=hier14(&lval);
         assert(sc_status==statFIRST || arg[argidx].ident== 0 || arg[argidx].tags!=NULL);
         switch (arg[argidx].ident) {


### PR DESCRIPTION
Fix for #64, #114.

<del>Just removed two lines that give a crash. I've tested this very much and it pretty stable.</del>

<del>Why it stable? Because in latest Pawn these lines also does not exist: [sc3.c#L2331-L2333](https://github.com/compuphase/pawn/blob/master/compiler/sc3.c#L2331-L2333). And I think it's a good reason to remove this.</del>