### PR TITLE
Recursion

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -817,6 +817,7 @@ SC_VDECL int pc_optimize;     /* (peephole) optimization level */
 SC_VDECL int pc_memflags;     /* special flags for the stack/heap usage */
 SC_VDECL int pc_naked;        /* if true mark following function as naked */
 SC_VDECL int pc_compat;       /* running in compatibility mode? */
+SC_VDECL int pc_recursion;    /* enable detailed recursion report? */
 
 SC_VDECL constvalue sc_automaton_tab; /* automaton table */
 SC_VDECL constvalue sc_state_tab;     /* state table */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1097,6 +1097,9 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       case 'p':
         strlcpy(pname,option_value(ptr),_MAX_PATH); /* set name of implicit include file */
         break;
+      case 'R':
+        pc_recursion=toggle_option(ptr,pc_recursion);
+        break;
 #if !defined SC_LIGHT
       case 'r':
         strlcpy(rname,option_value(ptr),_MAX_PATH); /* set name of report file */
@@ -1417,6 +1420,7 @@ static void about(void)
     pc_printf("             1    JIT-compatible optimizations only\n");
     pc_printf("             2    full optimizations\n");
     pc_printf("         -p<name> set name of \"prefix\" file\n");
+    pc_printf("         -R[+/-]  add detailed recursion report with call chains (default=%c)\n",pc_recursion ? '+' : '-');
 #if !defined SC_LIGHT
     pc_printf("         -r[name] write cross reference report to console or to specified file\n");
 #endif
@@ -4606,7 +4610,7 @@ static long max_stacksize(symbol *root,int *recursion)
     assert(symstack[1]==NULL);
     recursion_detected=0;
     size=max_stacksize_recurse(symstack,sym,rsymstack,0L,&maxparams,&recursion_detected);
-    if (recursion_detected) {
+    if (recursion_detected && pc_recursion) {
       if (rsymstack[1]==NULL) {
         pc_printf("recursion detected: function %s directly calls itself\n", sym->name);
       } else {

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4501,7 +4501,7 @@ static void reduce_referrers(symbol *root)
 }
 
 #if !defined SC_LIGHT
-static long max_stacksize_recurse(symbol **sourcesym,symbol *sym,long basesize,int *pubfuncparams,int *recursion)
+static long max_stacksize_recurse(symbol **sourcesym,symbol *sym,symbol **rsourcesym,long basesize,int *pubfuncparams,int *recursion)
 {
   long size,maxsize;
   int i,stkpos;
@@ -4517,6 +4517,8 @@ static long max_stacksize_recurse(symbol **sourcesym,symbol *sym,long basesize,i
     if (sym->refer[i]!=NULL) {
       assert(sym->refer[i]->ident==iFUNCTN);
       assert((sym->refer[i]->usage & uNATIVE)==0); /* a native function cannot refer to a user-function */
+      *(rsourcesym)=sym;
+      *(rsourcesym+1)=NULL;
       for (stkpos=0; sourcesym[stkpos]!=NULL; stkpos++) {
         if (sym->refer[i]==sourcesym[stkpos]) {   /* recursion detection */
           *recursion=1;
@@ -4527,7 +4529,7 @@ static long max_stacksize_recurse(symbol **sourcesym,symbol *sym,long basesize,i
       sourcesym[stkpos]=sym;
       sourcesym[stkpos+1]=NULL;
       /* check size of callee */
-      size=max_stacksize_recurse(sourcesym,sym->refer[i],sym->x.stacksize,pubfuncparams,recursion);
+      size=max_stacksize_recurse(sourcesym,sym->refer[i],rsourcesym+1,sym->x.stacksize,pubfuncparams,recursion);
       if (maxsize<size)
         maxsize=size;
       /* remove this symbol from the stack */
@@ -4570,7 +4572,7 @@ static long max_stacksize(symbol *root,int *recursion)
   long size,maxsize;
   int maxparams,numfunctions;
   symbol *sym;
-  symbol **symstack;
+  symbol **symstack,**rsymstack;
 
   assert(root!=NULL);
   assert(recursion!=NULL);
@@ -4585,27 +4587,46 @@ static long max_stacksize(symbol *root,int *recursion)
   } /* if */
   /* allocate function symbol stack */
   symstack=(symbol **)malloc((numfunctions+1)*sizeof(symbol*));
-  if (symstack==NULL)
+  rsymstack=(symbol **)malloc((numfunctions+1)*sizeof(symbol*));
+  if (symstack==NULL || rsymstack==NULL)
     error(103);         /* insufficient memory (fatal error) */
   memset(symstack,0,(numfunctions+1)*sizeof(symbol*));
+  memset(rsymstack,0,(numfunctions+1)*sizeof(symbol*));
 
   maxsize=0;
   maxparams=0;
   *recursion=0;         /* assume no recursion */
   for (sym=root->next; sym!=NULL; sym=sym->next) {
+    int recursion_detected;
     /* drop out if this is not a user-implemented function */
     if (sym->ident!=iFUNCTN || (sym->usage & uNATIVE)!=0)
       continue;
     /* accumulate stack size for this symbol */
     symstack[0]=sym;
     assert(symstack[1]==NULL);
-    size=max_stacksize_recurse(symstack,sym,0L,&maxparams,recursion);
+    recursion_detected=0;
+    size=max_stacksize_recurse(symstack,sym,rsymstack,0L,&maxparams,&recursion_detected);
+    if (recursion_detected) {
+      if (rsymstack[1]==NULL) {
+        pc_printf("recursion detected: function %s directly calls itself\n", sym->name);
+      } else {
+        int i;
+        pc_printf("recursion detected: function %s indirectly calls itself:\n", sym->name);
+        pc_printf("%s ", sym->name);
+        for (i=1; rsymstack[i]!=NULL; i++) {
+          pc_printf("<- %s ", rsymstack[i]->name);
+        }
+        pc_printf("<- %s\n", sym->name);
+      }
+      *recursion=recursion_detected;
+    }
     assert(size>=0);
     if (maxsize<size)
       maxsize=size;
   } /* for */
 
   free((void*)symstack);
+  free((void*)rsymstack);
   maxsize++;                  /* +1 because a zero cell is always pushed on top
                                * of the stack to catch stack overwrites */
   return maxsize+(maxparams+1);/* +1 because # of parameters is always pushed on entry */

--- a/source/compiler/scvars.c
+++ b/source/compiler/scvars.c
@@ -92,6 +92,7 @@ SC_VDEFINE int pc_optimize=sOPTIMIZE_NOMACRO; /* (peephole) optimization level *
 SC_VDEFINE int pc_memflags=0;      /* special flags for the stack/heap usage */
 SC_VDEFINE int pc_naked=FALSE;     /* if true mark following function as naked */
 SC_VDEFINE int pc_compat=FALSE;    /* running in compatibility mode? */
+SC_VDEFINE int pc_recursion=FALSE; /* enable detailed recursion report? */
 
 SC_VDEFINE constvalue sc_automaton_tab = { NULL, "", 0, 0}; /* automaton table */
 SC_VDEFINE constvalue sc_state_tab = { NULL, "", 0, 0};   /* state table */


### PR DESCRIPTION
I have found nice feature in your [recursion](https://github.com/Zeex/pawn/tree/recursion) branch. This is it but with adding -R parameter for enabling or disabling this feature.

Example:
```Pawn
f1() {
	f2();
}

f2() {
	f3();
}

f3() {
	f4();
}

f4() {
	f1();
}
```
will output:

recursion detected: function f1 indirectly calls itself:
f1 <- f4 <- f3 <- f2 <- f1
recursion detected: function f2 indirectly calls itself:
f2 <- f1 <- f4 <- f3 <- f2
recursion detected: function f3 indirectly calls itself:
f3 <- f2 <- f1 <- f4 <- f3
recursion detected: function f4 indirectly calls itself:
f4 <- f3 <- f2 <- f1 <- f4