### PR TITLE
Fix warning 204/203 in sizeof and tagof operators

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1370,6 +1370,7 @@ static int hier2(value *lval)
         error(224,st);          /* indeterminate array size in "sizeof" expression */
     } /* if */
     ldconst(lval->constval,sPRI);
+    markusage(sym,uREAD);
     while (paranthese--)
       needtoken(')');
     return FALSE;
@@ -1422,6 +1423,7 @@ static int hier2(value *lval)
     lval->ident=iCONSTEXPR;
     lval->constval=tag | PUBLICTAG;
     ldconst(lval->constval,sPRI);
+    markusage(sym,uREAD);
     while (paranthese--)
       needtoken(')');
     return FALSE;


### PR DESCRIPTION
````pawn
main() {
	new Float:tmp;
	printf("tagid: %08x", tagof tmp);

	new array[12];
	printf("sizeof: %d", sizeof array);
}
````

The compiler gives the warnings:
```
warning 204: symbol is assigned a value that is never used: "array"
warning 203: symbol is never used: "tmp"
```