### PR TITLE
Minor fixes/adjustments for the build script

### DIFF
--- a/source/compiler/CMakeLists.txt
+++ b/source/compiler/CMakeLists.txt
@@ -50,7 +50,8 @@ if(UNIX)
   link_libraries(pthread)
 endif()
 
-configure_file(version.h.in version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # The Pawn compiler shared library
@@ -73,7 +74,7 @@ set(PAWNC_SRCS
   scmemfil.c
   scstate.c
   scvars.c
-  ${CMAKE_BINARY_DIR}/version.h)
+  version.h)
 set_source_files_properties(sc1.c COMPILE_FLAGS -DNO_MAIN)
 if(WIN32)
   set(PAWNC_SRCS ${PAWNC_SRCS} libpawnc.rc)
@@ -81,7 +82,7 @@ if(WIN32)
   if(BORLAND)
     # Borland linker uses a DEF file if one is in the output directory
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libpawnc.def.borland
-                   ${CMAKE_BINARY_DIR}/pawnc.def
+                   ${CMAKE_CURRENT_BINARY_DIR}/pawnc.def
                    COPYONLY)
   else()
     # Microsoft Visual C/C++ supports a DEF file as if it were a source file
@@ -100,6 +101,7 @@ if(WATCOM)  #Watcom C/C++ does not support a .DEF file for the exports
 elseif(MINGW)
   set_target_properties(pawnc PROPERTIES LINK_FLAGS
     "-Wl,--enable-stdcall-fixup")
+  set_target_properties(pawnc PROPERTIES PREFIX "")
 endif()
 
 # The Pawn compiler driver (console program)
@@ -109,7 +111,7 @@ if(WIN32)
   if(BORLAND)
     # Borland linker uses a DEF file if one is in the output directory
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pawncc.def.borland
-                   ${CMAKE_BINARY_DIR}/pawncc.def
+                   ${CMAKE_CURRENT_BINARY_DIR}/pawncc.def
                    COPYONLY)
   else()
     # Microsoft Visual C/C++ supports a DEF file as if it were a source file


### PR DESCRIPTION
Just as the title says, the bugs fixed in this PR are minor and only show up if script `compiler/CMakeLists.txt` is used from another CMake script (with `add_subdirectory`).

1. When generating a project CMake can't find file `version.h`. `CMAKE_CURRENT_BINARY_DIR` and `CMAKE_BINARY_DIR` variables are used as if they are interchangeable while they actually aren't.
   `configure_file` command saves files into `CMAKE_CURRENT_BINARY_DIR` directory by default, not into `CMAKE_BINARY_DIR`.
2. For some reason when I compile the project (with `compiler/CMakeLists.txt` used from another CMake script too) with MinGW, it builds libpawnc.dll instead of pawnc.dll and pawncc.exe won't work because it needs pawnc.dll, without the "lib" prefix, so I removed it in the script.
   The prefix should probably be removed when building with Watcom C and/or Borland C as well, I just haven't tried building with these compilers yet.