### PR TITLE
fixes multi-dimesional array initilization bug

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2515,7 +2515,7 @@ static cell initarray(int ident,int tag,int dim[],int numdim,int cur,
                       constvalue *enumroot,int *errorfound)
 {
   cell dsize,totalsize;
-  int idx,idx_ellips,vidx;
+  int idx,idx_ellips,vidx, do_insert;
   int abortparse;
   int curlit;
   cell *prev1=NULL,*prev2=NULL;
@@ -2525,7 +2525,13 @@ static cell initarray(int ident,int tag,int dim[],int numdim,int cur,
   assert(cur+2<=numdim);        /* there must be 2 dimensions or more to do */
   assert(errorfound!=NULL && *errorfound==FALSE);
   totalsize=0;
-  needtoken('{');
+  needtoken('{');  
+  for (do_insert=0,idx=0; idx<=cur; idx++) {
+    if (dim[idx] == 0) {
+      do_insert = 1;
+      break;
+    } /* if */
+  } /* for */  
   for (idx=0,abortparse=FALSE; !abortparse; idx++) {
     /* In case the major dimension is zero, we need to store the offset
      * to the newly detected sub-array into the indirection table; i.e.
@@ -2535,7 +2541,7 @@ static cell initarray(int ident,int tag,int dim[],int numdim,int cur,
      * necessary at this point to reserve space for an extra cell in the
      * indirection vector.
      */
-    if (dim[cur]==0) {
+    if (do_insert) {
       litinsert(0,startlit);
     } else if (idx>=dim[cur]) {
       error(18);                /* initialization data exceeds array size */


### PR DESCRIPTION
Solves the bug described in issue #117

new [][2][3] = { //default values };
The compiler does not create enough room for the indirection tables and
hence adjust_indirectiontables overwrites the default values leaving the
array wrongly initilized.

Adds a generic code which works for any n-dimensional arrays (n = 1,
2,3,4,5... infinity). The code fixes the issue for any dimension but the
number of dimensions is limited to 4 (sDIMEN_MAX). A review of this code
won't be required if the limit is increased in the future.