### PR TITLE
fixes memory corruption with multi-dimensional arrays

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2456,12 +2456,18 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
       constvalue lastdim={NULL,"",0,0};     /* sizes of the final dimension */
       int skipdim=0;
 
-      if (dim[numdim-1]!=0)
-        *size=calc_arraysize(dim,numdim,0); /* calc. full size, if known */
+      /* check if the user has given the size of all dimensions */
+      for (idx = 0; idx < numdim; idx++)
+        if (dim[idx] == 0)
+          break;
       /* already reserve space for the indirection tables (for an array with
        * known dimensions)
        * (do not use dumpzero(), as it bypasses the literal queue)
        */
+      if(idx == numdim) 
+        *size=calc_arraysize(dim,numdim,0);  /* user has provided the size of all the dimensions, so calculate the size */
+      else 
+        *size = 0; /* user hasn't given the size for one or more dimensions */
       for (tablesize=calc_arraysize(dim,numdim-1,0); tablesize>0; tablesize--)
         litadd(0);
       /* now initialize the sub-arrays */


### PR DESCRIPTION
static const Test[2][][2] = { { { 9, 8 } },  { { 6, 7 } } };

The above code causes a memory corruption as the compiler does not
correctly calculate the size of the array.

This commit adds code to fix it.