### PR TITLE
Add 'Installation on openSUSE/SLES' section to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,18 @@ What is this?
 This is a modified copy of the Pawn compiler version 3.2.3664 by Compuphase that
 fixes some bugs and adds a few features.
 
+Installation on openSUSE/SLES
+---------------------
+There is an installation package available for openSUSE/SLES users so that you can easily install the compiler on your distribution. Please follow these steps:
+
+1. Go to https://build.opensuse.org/package/show/home:mschnitzer/pawncc
+2. On the right side, select your distribution (only if it's not disabled!)
+3. Click "Go to download repository"
+4. Copy the link and enter in sudo mode in your shell: `zypper ar $COPIED_LINK home:mschnitzer`
+5. Again as root, type: `zypper ref`
+6. Install the package with `zypper in pawncc`
+7. Run `pawncc` in your shell to test if it's working
+
 Changes
 -------
 


### PR DESCRIPTION
I'd like to suggest to add an `Installation on openSUSE/SLES` section to the README. One year ago, I started packaging your project for openSUSE distributions. The plan was to provide a package that everyone can install with openSUSE's package manager `zypper`. The package gets updated to the newest version when you release a new update. Users can then obtain the newest version when they update their distribution (command: `zypper up` ; would be equal to `apt-get update` on Debian/Ubuntu)

This makes it easier for users that have more than one computer/server to update to the newest version of this project.

I also planned to submit this package to the openSUSE distribution so that new released openSUSE distributions (next will be `Leap 42.3`) provide that package by default.