### PR TITLE
fixes deletion of constants passed a compiler args during parse

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1200,7 +1200,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       } /* if */
       strlcpy(str,argv[arg],i+1);       /* str holds symbol name */
       i=atoi(ptr+1);
-      add_constant(str,i,sGLOBAL,0);
+      add_builtin_constant(str,i,sGLOBAL,0);
     } else {
       strlcpy(str,argv[arg],sizeof(str)-2); /* -2 because default extension is ".p" */
       set_extension(str,".p",FALSE);


### PR DESCRIPTION
fix for issue #159 

When constants are passed as compiler arguments (`pawnc test.pwn myvar=10`), the compiler adds them to the symbol table using [add_constant](https://github.com/Zeex/pawn/blob/master/source/compiler/sc1.c#L1203). Before the compiler begins to parse the script, it[ removes all the symbols from the symbol table except the builtin/predefined constants](https://github.com/Zeex/pawn/blob/master/source/compiler/sc1.c#L583). While most of the symbols are added back to the symbol table as the script is parsed, the symbols passed as compiler arguments won't be added again (as the compiler options are not parsed again).

This PR changes the `add_constant` function call with `add_builtin_constant` so that the constants passed through the argument list is treated as a predefined constant (and hence not deleted).