### PR TITLE
trigger error if an array of unknown size is being returned

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1984,7 +1984,9 @@ static int nesting=0;
      * reserved memory block as a hidden parameter
      */
     retsize=(int)array_totalsize(symret);
-    assert(retsize>0);
+    if (retsize<=0) {
+      error(92,sym->name);
+    } /* if */
     modheap(retsize*sizeof(cell));/* address is in ALT */
     pushreg(sALT);                /* pass ALT as the last (hidden) parameter */
     decl_heap+=retsize;

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -128,7 +128,8 @@ static char *errmsg[] = {
 /*088*/  "public variables and local variables may not have states (symbol \"%s\")\n",
 /*089*/  "state variables may not be initialized (symbol \"%s\")\n",
 /*090*/  "public functions may not return arrays (symbol \"%s\")\n",
-/*091*/  "ambiguous constant; tag override is required (symbol \"%s\")\n"
+/*091*/  "ambiguous constant; tag override is required (symbol \"%s\")\n",
+/*092*/  "functions may not return arrays of unknown size (symbol \"%s\")\n"
 };
 
 static char *fatalmsg[] = {


### PR DESCRIPTION
Related issues: #154 #161 #177

This PR adds code to send an error message when a user tries to return an array of unknown size in a function.

As shown in the aforementioned issues, returning arrays of unknown size can give unexpected results. This is the case as it is practically impossible to move contents of one array into another without knowing the size of the arrays. 

The compiler aborts (due to a failed assertion) when an array of unknown size is being returned (unless a release build of the compiler is being used). This PR changes it to an error message.