### PR TITLE
 #pragma option 

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1272,7 +1272,8 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
 
 void parsesingleoption(char *argv)
 {
-  parseoptions(1, &argv, NULL, NULL, NULL, NULL, NULL);
+  char *args[2] = { 0, argv };
+  parseoptions(2, args, NULL, NULL, NULL, NULL, NULL);
 }
 
 #if !defined SC_LIGHT

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1053,8 +1053,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         #endif
         break;
       case 'c':
-        if (codepage)
-          strlcpy(codepage,option_value(ptr),MAXCODEPAGE);  /* set name of codepage */
+        strlcpy(codepage,option_value(ptr),MAXCODEPAGE);  /* set name of codepage */
         break;
       case 'D':                 /* set active directory */
         ptr=option_value(ptr);
@@ -1272,8 +1271,14 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
 
 void parsesingleoption(char *argv)
 {
+  /* argv[0] is the program, which we don't need here */
   char *args[2] = { 0, argv };
-  parseoptions(2, args, NULL, NULL, NULL, NULL, NULL);
+  char codepage[MAXCODEPAGE+1] = { 0 };
+  codepage[0] = '\0';
+  parseoptions(2, args, NULL, NULL, NULL, NULL, codepage);
+  /* need explicit support for codepages */
+  if (codepage[0] && !cp_set(codepage))
+    error(108);         /* codepage mapping file not found */
 }
 
 #if !defined SC_LIGHT

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1050,7 +1050,8 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         #endif
         break;
       case 'c':
-        strlcpy(codepage,option_value(ptr),MAXCODEPAGE);  /* set name of codepage */
+        if (codepage)
+          strlcpy(codepage,option_value(ptr),MAXCODEPAGE);  /* set name of codepage */
         break;
       case 'D':                 /* set active directory */
         ptr=option_value(ptr);
@@ -1082,7 +1083,8 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         } /* switch */
         break;
       case 'e':
-        strlcpy(ename,option_value(ptr),_MAX_PATH); /* set name of error file */
+        if (ename)
+          strlcpy(ename,option_value(ptr),_MAX_PATH); /* set name of error file */
         break;
 #if defined	__WIN32__ || defined _WIN32 || defined _Windows
       case 'H':
@@ -1108,7 +1110,8 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         sc_listing=TRUE;        /* skip second pass & code generation */
         break;
       case 'o':
-        strlcpy(oname,option_value(ptr),_MAX_PATH); /* set name of (binary) output file */
+        if (oname)
+          strlcpy(oname,option_value(ptr),_MAX_PATH); /* set name of (binary) output file */
         break;
       case 'O':
         pc_optimize=*option_value(ptr) - '0';
@@ -1116,13 +1119,16 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
           about();
         break;
       case 'p':
-        strlcpy(pname,option_value(ptr),_MAX_PATH); /* set name of implicit include file */
+        if (pname)
+          strlcpy(pname,option_value(ptr),_MAX_PATH); /* set name of implicit include file */
         break;
       case 'R':
         pc_recursion=toggle_option(ptr,pc_recursion);
         break;
 #if !defined SC_LIGHT
       case 'r':
+        if (!rname)
+          break;
         strlcpy(rname,option_value(ptr),_MAX_PATH); /* set name of report file */
         sc_makereport=TRUE;
         if (strlen(rname)>0) {
@@ -1230,7 +1236,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       strlcpy(str,argv[arg],i+1);       /* str holds symbol name */
       i=atoi(ptr+1);
       add_builtin_constant(str,i,sGLOBAL,0);
-    } else {
+    } else if (oname) {
       strlcpy(str,argv[arg],sizeof(str)-2); /* -2 because default extension is ".p" */
       set_extension(str,".p",FALSE);
       insert_sourcefile(str);
@@ -1259,6 +1265,11 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
 #endif
     } /* if */
   } /* for */
+}
+
+void parsesingleoption(char *argv)
+{
+  parseoptions(1, &argv, NULL, NULL, NULL, NULL, NULL);
 }
 
 #if !defined SC_LIGHT

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -945,6 +945,8 @@ enum {
  *  Global variables: iflevel, ifstack (altered)
  *                    lptr      (altered)
  */
+void parsesingleoption(char *argv);
+
 static int command(void)
 {
   int tok,ret;
@@ -1268,6 +1270,16 @@ static int command(void)
           sym=findconst("__compat",NULL);
           assert(sym!=NULL);
           sym->addr=pc_compat;
+        } else if (strcmp(str,"option")==0) {
+          char name[sNAMEMAX+1];
+          int i;
+          /* first gather all information, start with the tag name */
+          while (*lptr<=' ' && *lptr!='\0')
+            lptr++;
+          for (i=0; i<sizeof name && *lptr>' '; i++,lptr++)
+            name[i]=*lptr;
+          name[i]='\0';
+          parsesingleoption(name);
         } else {
           error(207);           /* unknown #pragma */
         } /* if */


### PR DESCRIPTION
```pawn
#pragma option
```

Allows you to specify command-line options within a script.  Some don't work, some already have other pragma equivalents, but some can't be done yet.  Could actually replace a huge number of other pragmas:

```pawn
#pragma tabsize 4
#pragma option -t4

#pragma ctrlchar \
#pragma option -\

#pragma semicolon 1
#pragma option -;+

#pragma warning disable 202
#pragma option -w202

#pragma compat 1
#pragma option -Z+

#define HELLO 42
#pragma option HELLO=42

#pragma codepage 1424
#pragma option -c1424

// NO EQUIVALENT
#pragma option -(+

// NO EQUIVALENT
#pragma option -l

// NO EQUIVALENT
#pragma option -E

// NO EQUIVALENT
#pragma option -a

// etc...
```

Certain options are disabled in this manner, because they would alter details too fundamental, such as input and output files, that can't be changed after you already started reading said files:

```
-e
-o
-p
-r
```

Note that it will only read up to about 32 characters from the option, since it isn't really designed for long ones.  Speaking of which, a lot of the existing `pragma` code uses `i<sizeof name` and `name[i]='\0'`, which is technically a buffer overflow, but as far as I can see only ever writes an extra zero in to a subsequently unused variable, so is entirely safe.

