### PR TITLE
Do not allow to redefine labels

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5820,6 +5820,8 @@ static void dolabel(void)
   if (find_constval(&tagname_tab,st,0)!=NULL)
     error(221,st);      /* label name shadows tagname */
   sym=fetchlab(st);
+  if ((sym->usage & uDEFINE)!=0)
+    error(21,st);       /* symbol already defined */
   setlabel((int)sym->addr);
   /* since one can jump around variable declarations or out of compound
    * blocks, the stack must be manually adjusted


### PR DESCRIPTION
```Pawn
test()
{
my_label:
    // ...
    if (/* ... */)
        goto my_label; // the jump is made to the place of the 2'nd
                       // definition of 'my_label' below
    // ...
my_label: // before this PR there are no errors/warnings at label redefinition
}
```
After this PR the compiler issues error 021 ('symbol already defined: "my_label"').
The same bug has been fixed in Pawn 4.0 a year ago.