### PR TITLE
debug info for tag mismatch warnings

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -554,6 +554,7 @@ long pc_lengthbin(void *handle); /* return the length of the file */
 SC_FUNC void set_extension(char *filename,char *extension,int force);
 SC_FUNC symbol *fetchfunc(char *name,int tag);
 SC_FUNC char *operator_symname(char *symname,char *opername,int tag1,int tag2,int numtags,int resulttag);
+SC_FUNC constvalue *find_tag_byval(int tag);
 SC_FUNC char *funcdisplayname(char *dest,char *funcname);
 SC_FUNC int constexpr(cell *val,int *tag,symbol **symptr);
 SC_FUNC constvalue *append_constval(constvalue *table,const char *name,cell val,int index);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2352,8 +2352,15 @@ static int declloc(int fstatic)
         assert(staging);        /* end staging phase (optimize expression) */
         stgout(staging_start);
         stgset(FALSE);
-        if (!matchtag(tag,ctag,TRUE))
-          error(213);           /* tag mismatch */
+        if (!matchtag(tag,ctag,TRUE)) {
+          constvalue *tagsym;
+          char *formal_tagname,*actual_tagname;
+          tagsym=find_tag_byval(tag);
+          formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+          tagsym=find_tag_byval(ctag);
+          actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+          error(213,formal_tagname,actual_tagname); /* tag mismatch */
+        } /* if */
         /* if the variable was not explicitly initialized, reset the
          * "uWRITTEN" flag that store() set */
         if (!explicit_init)
@@ -2508,8 +2515,15 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
   if (ident==iVARIABLE) {
     assert(*size==1);
     init(ident,&ctag,NULL);
-    if (!matchtag(tag,ctag,TRUE))
-      error(213);       /* tag mismatch */
+    if (!matchtag(tag,ctag,TRUE)) {
+      constvalue *tagsym;
+      char *formal_tagname,*actual_tagname;
+      tagsym=find_tag_byval(tag);
+      formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      tagsym=find_tag_byval(ctag);
+      actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      error(213,formal_tagname,actual_tagname); /* tag mismatch */
+    } /* if */
   } else {
     assert(numdim>0);
     if (numdim==1) {
@@ -2736,14 +2750,28 @@ static cell initvector(int ident,int tag,cell size,int startlit,int fillzero,
         rtag=symfield->x.tags.index;  /* set the expected tag to the index tag */
         enumfield=enumfield->next;
       } /* if */
-      if (!matchtag(rtag,ctag,TRUE))
-        error(213);            /* tag mismatch */
+      if (!matchtag(rtag,ctag,TRUE)) {
+        constvalue *tagsym;
+        char *formal_tagname,*actual_tagname;
+        tagsym=find_tag_byval(rtag);
+        formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+        tagsym=find_tag_byval(ctag);
+        actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+        error(213,formal_tagname,actual_tagname); /* tag mismatch */
+      } /* if */
     } while (matchtoken(',')); /* do */
     needtoken('}');
   } else {
     init(ident,&ctag,errorfound);
-    if (!matchtag(tag,ctag,TRUE))
-      error(213);               /* tagname mismatch */
+    if (!matchtag(tag,ctag,TRUE)) {
+      constvalue *tagsym;
+      char *formal_tagname,*actual_tagname;
+      tagsym=find_tag_byval(tag);
+      formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      tagsym=find_tag_byval(ctag);
+      actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      error(213,formal_tagname,actual_tagname); /* tag mismatch */
+    } /* if */
   } /* if */
   /* fill up the literal queue with a series */
   if (ellips) {
@@ -2855,10 +2883,16 @@ static void decl_const(int vclass)
     constexpr(&val,&exprtag,NULL);      /* get value */
     /* add_constant() checks for duplicate definitions */
     if (!matchtag(tag,exprtag,FALSE)) {
+      constvalue *tagsym;
+      char *formal_tagname,*actual_tagname;
       /* temporarily reset the line number to where the symbol was defined */
       int orgfline=fline;
-      fline=symbolline;
-      error(213);                       /* tagname mismatch */
+      fline=symbolline;     
+      tagsym=find_tag_byval(tag);
+      formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      tagsym=find_tag_byval(exprtag);
+      actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      error(213,formal_tagname,actual_tagname); /* tag mismatch */
       fline=orgfline;
     } /* if */
     sym=add_constant(constname,val,vclass,tag);
@@ -3397,7 +3431,7 @@ static int parse_funcname(char *fname,int *tag1,int *tag2,char *opname)
   return unary;
 }
 
-static constvalue *find_tag_byval(int tag)
+SC_FUNC constvalue *find_tag_byval(int tag)
 {
   constvalue *tagsym;
   tagsym=find_constval_byval(&tagname_tab,tag & ~PUBLICTAG);
@@ -4113,8 +4147,15 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
       } else {
         constexpr(&arg->defvalue.val,&arg->defvalue_tag,NULL);
         assert(numtags>0);
-        if (!matchtag(tags[0],arg->defvalue_tag,TRUE))
-          error(213);           /* tagname mismatch */
+        if (!matchtag(tags[0],arg->defvalue_tag,TRUE)) {
+          constvalue *tagsym;
+          char *formal_tagname,*actual_tagname;
+          tagsym=find_tag_byval(tags[0]);
+          formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+          tagsym=find_tag_byval(arg->defvalue_tag);
+          actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+          error(213,formal_tagname,actual_tagname); /* tag mismatch */
+        } /* if */
       } /* if */
     } /* if */
   } /* if */
@@ -6770,8 +6811,15 @@ static void doreturn(void)
     rettype|=uRETVALUE;                 /* function returns a value */
     /* check tagname with function tagname */
     assert(curfunc!=NULL);
-    if (!matchtag(curfunc->tag,tag,TRUE))
-      error(213);                       /* tagname mismatch */
+    if (!matchtag(curfunc->tag,tag,TRUE)) {
+      constvalue *tagsym;
+      char *formal_tagname,*actual_tagname;
+      tagsym=find_tag_byval(curfunc->tag);
+      formal_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      tagsym=find_tag_byval(tag);
+      actual_tagname=(tagsym!=NULL) ? tagsym->name : "-unknown-";
+      error(213,formal_tagname,actual_tagname); /* tag mismatch */
+    } /* if */
     if (ident==iARRAY || ident==iREFARRAY) {
       int dim[sDIMEN_MAX],numdim=0;
       cell arraysize;

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2201,7 +2201,7 @@ static int nesting=0;
             for (i=0; i<arg[argidx].numtags; i++) {
               tagsym=find_tag_byval(arg[argidx].tags[i]);
               strlcat(formal_tagnames,(tagsym!=NULL) ? tagsym->name : "-unknown-",sizeof(formal_tagnames));
-              if(i!=arg[argidx].numtags)
+              if((i+1)!=arg[argidx].numtags)
                 strlcat(formal_tagnames,"\" or \"",sizeof(formal_tagnames));
             }
             tagsym=find_tag_byval(lval.tag);
@@ -2228,7 +2228,7 @@ static int nesting=0;
             for (i=0; i<arg[argidx].numtags; i++) {
               tagsym=find_tag_byval(arg[argidx].tags[i]);
               strlcat(formal_tagnames,(tagsym!=NULL) ? tagsym->name : "-unknown-",sizeof(formal_tagnames));
-              if(i!=arg[argidx].numtags)
+              if((i+1)!=arg[argidx].numtags)
                 strlcat(formal_tagnames,"\" or \"",sizeof(formal_tagnames));
             }
             tagsym=find_tag_byval(lval.tag);
@@ -2263,7 +2263,7 @@ static int nesting=0;
             for (i=0; i<arg[argidx].numtags; i++) {
               tagsym=find_tag_byval(arg[argidx].tags[i]);
               strlcat(formal_tagnames,(tagsym!=NULL) ? tagsym->name : "-unknown-",sizeof(formal_tagnames));
-              if(i!=arg[argidx].numtags)
+              if((i+1)!=arg[argidx].numtags)
                 strlcat(formal_tagnames,"\" or \"",sizeof(formal_tagnames));
             }
             tagsym=find_tag_byval(lval.tag);
@@ -2353,7 +2353,7 @@ static int nesting=0;
             for (i=0; i<arg[argidx].numtags; i++) {
               tagsym=find_tag_byval(arg[argidx].tags[i]);
               strlcat(formal_tagnames,(tagsym!=NULL) ? tagsym->name : "-unknown-",sizeof(formal_tagnames));
-              if(i!=arg[argidx].numtags)
+              if((i+1)!=arg[argidx].numtags)
                 strlcat(formal_tagnames,"\" or \"",sizeof(formal_tagnames));
             }
             tagsym=find_tag_byval(lval.tag);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -167,7 +167,7 @@ static char *warnmsg[] = {
 /*210*/  "possible use of symbol before initialization: \"%s\"\n",
 /*211*/  "possibly unintended assignment\n",
 /*212*/  "possibly unintended bitwise operation\n",
-/*213*/  "tag mismatch\n",
+/*213*/  "tag mismatch: expected tag(s) \"%s\", but found \"%s\"\n",
 /*214*/  "possibly a \"const\" array argument was intended: \"%s\"\n",
 /*215*/  "expression has no effect\n",
 /*216*/  "nested comment\n",


### PR DESCRIPTION
This commit adds useful information to the "tag mismatch" warning.

**Basic tests:**
```
enum PInfo_t {
Money,
Score
}

TAG_H:func1(TAG_G:arg1 = 5, {TAG_I_1, TAG_I_2, TAG_I_3}:arg2 = 5, {TAG_J_1, TAG_J_2, TAG_J_3}:arg3[] = {1, TAG_J_4:2, TAG_J_5:3}) { return 5; }
func2(arg) { }
main() {
	new TAG_A:var1 = 5;
	new TAG_B:arr1[] = {TAG_B_1:5, TAG_B_2:2};
	new TAG_C:str1[] = "abcdefg";
	new TAG_D:str2[2][] = {"abc", "efg"};
	new TAG_E:arr2[2][] = {{1}, {2}};
	const TAG_F:var2 = TAG_F_1:6;

	func1();
	func1(TAG_G_1:66, 6);
	
	new Money = 5;
	func2(Money);
	func1(TAG_G_1:66)
}
```

```
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_G", but found "_"
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_I_1", but found "_"
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_J_1", but found "_"
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_J_1", but found "TAG_J_4"
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_J_1", but found "TAG_J_5"
test.pwn(6) : warning 213: tag mismatch: expected tag(s) "TAG_H", but found "_"
test.pwn(9) : warning 213: tag mismatch: expected tag(s) "TAG_A", but found "_"
test.pwn(10) : warning 213: tag mismatch: expected tag(s) "TAG_B", but found "TAG_B_1"
test.pwn(10) : warning 213: tag mismatch: expected tag(s) "TAG_B", but found "TAG_B_2"
test.pwn(11) : warning 213: tag mismatch: expected tag(s) "TAG_C", but found "_"
test.pwn(12) : warning 213: tag mismatch: expected tag(s) "TAG_D", but found "_"
test.pwn(12) : warning 213: tag mismatch: expected tag(s) "TAG_D", but found "_"
test.pwn(13) : warning 213: tag mismatch: expected tag(s) "TAG_E", but found "_"
test.pwn(13) : warning 213: tag mismatch: expected tag(s) "TAG_E", but found "_"
test.pwn(14) : warning 213: tag mismatch: expected tag(s) "TAG_F", but found "TAG_F_1"
test.pwn(17) : warning 213: tag mismatch: expected tag(s) "TAG_G", but found "TAG_G_1"
test.pwn(17) : warning 213: tag mismatch: expected tag(s) "TAG_I_1" or "TAG_I_2" or "TAG_I_3", but found "_"
test.pwn(20) : warning 213: tag mismatch: expected tag(s) "_", but found "PInfo_t"
test.pwn(21) : warning 213: tag mismatch: expected tag(s) "TAG_G", but found "TAG_G_1"
```

**Bugs found using this PR:**
-- 1.

`tag mismatch: expected tag(s) "TAG_I_1", but found "_"`

`tag mismatch: expected tag(s) "TAG_J_1", but found "_"`

the compiler does not check all tags given inside a `{}` for an argument of a function (#145).
  