### PR TITLE
fixes inconsistencies with the tagof operator

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1424,10 +1424,13 @@ static int hier2(value *lval)
       else if (level==sym->dim.array.level+1 && idxsym!=NULL)
         tag=idxsym->x.tags.index;
     } /* if */
-    exporttag(tag);
+    if (tag!=0) {
+      exporttag(tag);
+      tag |= PUBLICTAG;
+    } /* if */
     clear_value(lval);
     lval->ident=iCONSTEXPR;
-    lval->constval=tag | PUBLICTAG;
+    lval->constval=tag;
     ldconst(lval->constval,sPRI);
     while (paranthese--)
       needtoken(')');


### PR DESCRIPTION
#160 

The standalone tagof operator tries to export tall tags which it works with.

The tagof operator when used as a default argument checks if the tag is zero before exporting.

As the zero tag identifier cannot be exported (even if its `PUBLICTAG` bit is set), it makes sense to use `0` as tag identifier instead of `0 | PUBLICTAG`.

This commit changes the standalone tagof operator behavior so that the zero tag identifier does not get its `PUBLICTAG` bit set.