### PR TITLE
warning for meaningless class combinations

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3867,6 +3867,8 @@ static int declargs(symbol *sym,int chkshadow)
       case '&':
         if (ident!=iVARIABLE || numtags>0)
           error(1,"-identifier-","&");
+        if (fconst)
+          error(238, "const reference"); /* meaningless combination of class specifiers */
         ident=iREFERENCE;
         break;
       case tCONST:
@@ -3941,6 +3943,8 @@ static int declargs(symbol *sym,int chkshadow)
       case tELLIPS:
         if (ident!=iVARIABLE)
           error(10);                    /* illegal function or declaration */
+        if (fconst)
+          error(238, "const variable arguments"); /* meaningless combination of class specifiers */
         if (numtags==0)
           tags[numtags++]=0;            /* default tag */
         if ((sym->usage & uPROTOTYPED)==0) {

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -191,7 +191,8 @@ static char *warnmsg[] = {
 /*234*/  "function is deprecated (symbol \"%s\") %s\n",
 /*235*/  "public function lacks forward declaration (symbol \"%s\")\n",
 /*236*/  "unknown parameter in substitution (incorrect #define pattern)\n",
-/*237*/  "user warning: %s\n"
+/*237*/  "user warning: %s\n",
+/*238*/  "meaningless combination of class specifiers (%s)\n"
 };
 
 #define NUM_WARNINGS    (sizeof warnmsg / sizeof warnmsg[0])

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -40,6 +40,12 @@ set_tests_properties(unused_symbol_line_gh_252 PROPERTIES PASS_REGULAR_EXPRESSIO
 .*\\.pwn\\(1\\) : warning 203: symbol is never used: \\\"x\\\"
 ")
 
+add_compiler_test(meaningless_class_specifiers_gh_172 ${CMAKE_CURRENT_SOURCE_DIR}/meaningless_class_specifiers_gh_172.pwn)
+set_tests_properties(meaningless_class_specifiers_gh_172 PROPERTIES PASS_REGULAR_EXPRESSION "\
+.*\\.pwn\\(1\\) : warning 238: meaningless combination of class specifiers \\(const reference\\)\
+.*\\.pwn\\(2\\) : warning 238: meaningless combination of class specifiers \\(const variable arguments\\)\
+")
+
 # Crashers
 #
 # These tests simply check that the compiler doesn't crash.

--- a/source/compiler/tests/meaningless_class_specifiers_gh_172.pwn
+++ b/source/compiler/tests/meaningless_class_specifiers_gh_172.pwn
@@ -1,0 +1,20 @@
+f1(const &v) { }
+f2(const ...) { }
+f3(const v) {
+	#pragma unused v
+}
+f4(...) { }
+f5(v) {
+	#pragma unused v
+}
+f6(&v) { }
+
+main() {
+	new a;
+	f1(a);
+	f2(a);
+	f3(a);
+	f4(a);
+	f5(a);
+	f6(a);
+}


### PR DESCRIPTION
#172 

1. Adds a generic new warning which is triggered when meaningless combination of class specifiers are used.

2. This commit adds code to trigger a warning for the following two cases:
- constant reference
- - not meaningful as as references always point to cells in PAWN (unlike C++ where it would help prevent costly copies while guaranteeing to not modify the object) which makes const reference as good as pass-by-value
- constant variable arguments
- - for similar reasons as in the previous case