### PR TITLE
fixes several bugs associated with destructors

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4845,7 +4845,7 @@ static cell calc_array_datasize(symbol *sym, cell *offset)
     if (offset!=NULL)
       *offset=length*(*offset+sizeof(cell));
     if (sublength>0)
-      length*=length*sublength;
+      length*=sublength;
     else
       length=0;
   } else {
@@ -4875,6 +4875,15 @@ static void destructsymbols(symbol *root,int level)
         } /* if */
         /* if the variable is an array, get the number of elements */
         if (sym->ident==iARRAY) {
+          /* according to the PAWN Implementer Guide, the destructor
+           * should be triggered for the data of the array only; hence
+           * if the array is a part of a larger array, it must be ignored
+           * as it's parent would(or has already) trigger(ed) the destructor
+           */
+          if (sym->parent != NULL) {
+            sym=sym->next;
+            continue;
+          }
           elements=calc_array_datasize(sym,&offset);
           /* "elements" can be zero when the variable is declared like
            *    new mytag: myvar[2][] = { {1, 2}, {3, 4} }

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3752,6 +3752,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
     declared=0;
   } /* if */
   if ((lastst!=tRETURN) && (lastst!=tGOTO)){
+    destructsymbols(&loctab, 0);
     ldconst(0,sPRI);
     ffret(strcmp(sym->name,uENTRYFUNC)!=0);
     if ((sym->usage & uRETVALUE)!=0 && (sym->flags & flagNAKED)==0) {

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4861,7 +4861,7 @@ static void destructsymbols(symbol *root,int level)
   int savepri=FALSE;
   symbol *sym=root->next;
   while (sym!=NULL && sym->compound>=level) {
-    if (sym->ident==iVARIABLE || sym->ident==iARRAY) {
+    if ((sym->ident==iVARIABLE || sym->ident==iARRAY) && !(sym->vclass == sSTATIC && sym->fnumber == -1)) {
       char symbolname[16];
       symbol *opsym;
       cell elements;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3752,7 +3752,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
     declared=0;
   } /* if */
   if ((lastst!=tRETURN) && (lastst!=tGOTO)){
-    destructsymbols(&loctab, 0);
+    destructsymbols(&loctab,0);
     ldconst(0,sPRI);
     ffret(strcmp(sym->name,uENTRYFUNC)!=0);
     if ((sym->usage & uRETVALUE)!=0 && (sym->flags & flagNAKED)==0) {
@@ -4861,7 +4861,7 @@ static void destructsymbols(symbol *root,int level)
   int savepri=FALSE;
   symbol *sym=root->next;
   while (sym!=NULL && sym->compound>=level) {
-    if ((sym->ident==iVARIABLE || sym->ident==iARRAY) && !(sym->vclass == sSTATIC && sym->fnumber == -1)) {
+    if ((sym->ident==iVARIABLE || sym->ident==iARRAY) && !(sym->vclass==sSTATIC && sym->fnumber==-1)) {
       char symbolname[16];
       symbol *opsym;
       cell elements;
@@ -4880,10 +4880,10 @@ static void destructsymbols(symbol *root,int level)
            * if the array is a part of a larger array, it must be ignored
            * as it's parent would(or has already) trigger(ed) the destructor
            */
-          if (sym->parent != NULL) {
+          if (sym->parent!=NULL) {
             sym=sym->next;
             continue;
-          }
+          } /* if */
           elements=calc_array_datasize(sym,&offset);
           /* "elements" can be zero when the variable is declared like
            *    new mytag: myvar[2][] = { {1, 2}, {3, 4} }


### PR DESCRIPTION
#256 #257

1. destructors are not called for static locals
2. destructors are called on implicit return (wasn't being called previously)
3. destructors are called only for the data of the array (destructors were called for indirection tables previously)

> The destructor operator takes an array with a single dimension on input, and this array holds all elements of a variable that must be destructed: 
> - For simple variables, the variable is passed by reference, which makes it appear as an array with one element. 
> - For arrays with one dimension, the array is passed without modiﬁcation 
> - For arrays with two or more dimensions, the destructor operator receives the address behind the “indirection tables” for the major dimensions. As documented above, a multi-dimensional array starts with vectors for the major dimensions that each hold the oﬀsets to the dimension below itself. The data for the array itself is packed behind these oﬀset arrays. By passing the address where the array data starts, the destructor operator can access the array elements as if it were an array with a single dimension.
