### PR TITLE
debug info for tagmismatch warnings

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -549,6 +549,8 @@ long pc_lengthbin(void *handle); /* return the length of the file */
 SC_FUNC void set_extension(char *filename,char *extension,int force);
 SC_FUNC symbol *fetchfunc(char *name,int tag);
 SC_FUNC char *operator_symname(char *symname,char *opername,int tag1,int tag2,int numtags,int resulttag);
+SC_FUNC void check_tagmismatch(int formaltag,int actualtag,int allowcoerce,int errline);
+SC_FUNC void check_tagmismatch_multiple(int formaltags[],int numtags,int actualtag,int errline);
 SC_FUNC char *funcdisplayname(char *dest,char *funcname);
 SC_FUNC int constexpr(cell *val,int *tag,symbol **symptr);
 SC_FUNC constvalue *append_constval(constvalue *table,const char *name,cell val,int index);
@@ -603,6 +605,7 @@ SC_FUNC char *itoh(ucell val);
 SC_FUNC int check_userop(void (*oper)(void),int tag1,int tag2,int numparam,
                          value *lval,int *resulttag);
 SC_FUNC int matchtag(int formaltag,int actualtag,int allowcoerce);
+SC_FUNC int checktag(int tags[],int numtags,int exprtag);
 SC_FUNC int expression(cell *val,int *tag,symbol **symptr,int chkfuncresult);
 SC_FUNC int sc_getstateid(constvalue **automaton,constvalue **state);
 SC_FUNC cell array_totalsize(symbol *sym);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -167,7 +167,7 @@ static char *warnmsg[] = {
 /*210*/  "possible use of symbol before initialization: \"%s\"\n",
 /*211*/  "possibly unintended assignment\n",
 /*212*/  "possibly unintended bitwise operation\n",
-/*213*/  "tag mismatch\n",
+/*213*/  "tag mismatch: expected tag(s) \"%s\", but found \"%s\"\n",
 /*214*/  "possibly a \"const\" array argument was intended: \"%s\"\n",
 /*215*/  "expression has no effect\n",
 /*216*/  "nested comment\n",

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -167,7 +167,7 @@ static char *warnmsg[] = {
 /*210*/  "possible use of symbol before initialization: \"%s\"\n",
 /*211*/  "possibly unintended assignment\n",
 /*212*/  "possibly unintended bitwise operation\n",
-/*213*/  "tag mismatch: expected tag(s) \"%s\", but found \"%s\"\n",
+/*213*/  "tag mismatch: expected %s %s but found %s\n",
 /*214*/  "possibly a \"const\" array argument was intended: \"%s\"\n",
 /*215*/  "expression has no effect\n",
 /*216*/  "nested comment\n",


### PR DESCRIPTION
This commit adds useful information to the "tag mismatch" warning.

**Basic tests:**
```
#pragma warning disable 203
#pragma warning disable 204
#pragma warning disable 219

enum PInfo_t {
	Money,
	Score
}

TAG_H:func1(TAG_G:arg1 = 5,
			 {TAG_I_1, TAG_I_2, _, TAG_I_3}:arg2 = 5,
			    {TAG_J_1}:arg3 = TAG_J_2:5,
			        {_}:arg4 = TAG_K_1:5,
			 	 		{TAG_L_1, TAG_L_2, TAG_L_3}:arg5[] = {1, TAG_L_4:2, TAG_L_5:3})
{
	return 5;
}

func2(arg) { }

main() {
	new TAG_A:var1 = 5;
	new TAG_B:arr1[] = {TAG_B_1:5, TAG_B_2:2};
	new TAG_C:str1[] = "abcdefg";
	new TAG_D:str2[2][] = {"abc", "efg"};
	new TAG_E:arr2[2][] = {{1}, {2}};
	const TAG_F:var2 = TAG_F_1:6;

	func1();
	func1(TAG_G_1:66, AA:6);

	new Money = 5;
	func2(Money);
	func1(TAG_G_1:66);
}
```

```
test.pwn(10) : warning 213: tag mismatch: expected tag "TAG_G", but found none ("_")
test.pwn(11) : warning 213: tag mismatch: expected tag "TAG_I_1", but found none ("_")
test.pwn(12) : warning 213: tag mismatch: expected tag "TAG_J_1", but found "TAG_J_2"
test.pwn(13) : warning 213: tag mismatch: expected tag none ("_"), but found "TAG_K_1"
test.pwn(14) : warning 213: tag mismatch: expected tag "TAG_L_1", but found none ("_")
test.pwn(14) : warning 213: tag mismatch: expected tag "TAG_L_1", but found "TAG_L_4"
test.pwn(14) : warning 213: tag mismatch: expected tag "TAG_L_1", but found "TAG_L_5"
test.pwn(16) : warning 213: tag mismatch: expected tag "TAG_H", but found none ("_")
test.pwn(22) : warning 213: tag mismatch: expected tag "TAG_A", but found none ("_")
test.pwn(23) : warning 213: tag mismatch: expected tag "TAG_B", but found "TAG_B_1"
test.pwn(23) : warning 213: tag mismatch: expected tag "TAG_B", but found "TAG_B_2"
test.pwn(24) : warning 213: tag mismatch: expected tag "TAG_C", but found none ("_")
test.pwn(25) : warning 213: tag mismatch: expected tag "TAG_D", but found none ("_")
test.pwn(25) : warning 213: tag mismatch: expected tag "TAG_D", but found none ("_")
test.pwn(26) : warning 213: tag mismatch: expected tag "TAG_E", but found none ("_")
test.pwn(26) : warning 213: tag mismatch: expected tag "TAG_E", but found none ("_")
test.pwn(27) : warning 213: tag mismatch: expected tag "TAG_F", but found "TAG_F_1"
test.pwn(30) : warning 213: tag mismatch: expected tag "TAG_G", but found "TAG_G_1"
test.pwn(30) : warning 213: tag mismatch: expected tags "TAG_I_1", "TAG_I_2", "TAG_I_3", or none ("_"); but found "AA"
test.pwn(33) : warning 213: tag mismatch: expected tag none ("_"), but found "PInfo_t"
test.pwn(34) : warning 213: tag mismatch: expected tag "TAG_G", but found "TAG_G_1"
```