### PR TITLE
Documentation improvement ▼

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -155,9 +155,10 @@ typedef struct s_symbol {
     } array;
   } dim;                /* for 'dimension', both functions and arrays */
   constvalue *states;   /* list of state function/state variable ids + addresses */
-  int fnumber;          /* static global variables: file number in which the declaration is visible */
+  int fnumber;          /* file number where is declared */
   int lnumber;          /* line number (in the current source file) for the declaration */
-  int lnumber_end;      /* line number (in the current source file) for the end of declaration */
+  int lnumber_decl;     /* line number where starts the declaration (ignore prototype) */
+  int lnumber_end;      /* line number for the end of declaration */
   struct s_symbol **refer;  /* referrer list, functions that "use" this symbol */
   int numrefers;        /* number of entries in the referrer list */
   char *documentation;  /* optional documentation string */
@@ -194,6 +195,7 @@ typedef struct s_symbol {
  *        3     (uCONST) the variable is constant (may not be assigned to)
  *        4     (uPUBLIC) the variable is public
  *        6     (uSTOCK) the variable is discardable (without warning)
+ *        7     (uSTATIC) the variable is static
  *
  *  FUNCTION
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
@@ -205,6 +207,7 @@ typedef struct s_symbol {
  *        6     (uSTOCK) the function is discardable (without warning)
  *        7     (uMISSING) the function is not implemented in this source file
  *        8     (uFORWARD) the function is explicitly forwardly declared
+ *        9     (uSTATIC) the function is static
  *
  *  CONSTANT
  *  bits: 0     (uDEFINE) the symbol is defined in the source file
@@ -213,6 +216,7 @@ typedef struct s_symbol {
  *        3     (uPREDEF) the constant is pre-defined and should be kept between passes
  *        5     (uENUMROOT) the constant is the "root" of an enumeration
  *        6     (uENUMFIELD) the constant is a field in a named enumeration
+ *        7     (uSTATIC) the function is static
  */
 #define uDEFINE     0x001
 #define uREAD       0x002
@@ -228,6 +232,7 @@ typedef struct s_symbol {
 #define uENUMFIELD  0x040
 #define uMISSING    0x080
 #define uFORWARD    0x100
+#define uSTATIC     0x200
 /* uRETNONE is not stored in the "usage" field of a symbol. It is
  * used during parsing a function, to detect a mix of "return;" and
  * "return value;" in a few special cases.

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -157,6 +157,7 @@ typedef struct s_symbol {
   constvalue *states;   /* list of state function/state variable ids + addresses */
   int fnumber;          /* static global variables: file number in which the declaration is visible */
   int lnumber;          /* line number (in the current source file) for the declaration */
+  int lnumber_end;      /* line number (in the current source file) for the end of declaration */
   struct s_symbol **refer;  /* referrer list, functions that "use" this symbol */
   int numrefers;        /* number of entries in the referrer list */
   char *documentation;  /* optional documentation string */
@@ -560,7 +561,7 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag);
 SC_FUNC symbol *add_builtin_constant(char *name,cell val,int vclass,int tag);
 SC_FUNC symbol *add_builtin_string_constant(char *name,const char *val,int vclass);
 SC_FUNC void exporttag(int tag);
-SC_FUNC void sc_attachdocumentation(symbol *sym);
+SC_FUNC void sc_attachdocumentation(symbol *sym,int onlylastblock);
 SC_FUNC void emit_parse_line(void);
 
 /* function prototypes in SC2.C */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1910,7 +1910,7 @@ void sc_attachdocumentation(symbol *sym,int onlylastblock)
         size_t len;
         strcpy(doc,sym->documentation);
         len=strlen(doc);
-        if (len>0 && doc[len-1]!='>' || ((str=get_docstring(0))!=NULL && *str!=sDOCSEP && *str!='<'))
+        if ((len>0 && doc[len-1]!='>') || ((str=get_docstring(0))!=NULL && *str!=sDOCSEP && *str!='<'))
           strcat(doc,"<p/>");
         free(sym->documentation);
         sym->documentation=NULL;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2893,10 +2893,12 @@ static void decl_const(int vclass)
     /* add_constant() checks for duplicate definitions */
     check_tagmismatch(tag,exprtag,FALSE,symbolline);
     sym=add_constant(constname,val,vclass,tag);
-    if (sym!=NULL)
-      //LINE_START
-      //LINE_END
+    if (sym!=NULL) {
+      sym->fnumber = fcurrent;
+      sym->lnumber_decl = symbolline;
+      sym->lnumber_end = symbolline;
       sc_attachdocumentation(sym,TRUE);/* attach any documentation to the constant */
+    }
   } while (matchtoken(',')); /* enddo */   /* more? */
   needtoken(tTERM);
 }
@@ -4533,7 +4535,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
     if (sym->ident!=iCONSTEXPR || (sym->usage & uENUMROOT)==0)
       continue;
     fprintf(log,"\t\t<member name=\"T:%s\" value=\"%"PRIdC"\">\n",funcdisplayname(symname,sym->name),sym->addr);
-    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\">\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
+    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\"/>\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
     write_docattributes(log,sym);
     if (sym->tag!=0) {
       tagsym=find_tag_byval(sym->tag);
@@ -4585,7 +4587,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
     if ((sym->usage & uREAD)==0 || (sym->usage & (uENUMFIELD | uENUMROOT))!=0)
       continue;
     fprintf(log,"\t\t<member name=\"C:%s\" value=\"%"PRIdC"\">\n",funcdisplayname(symname,sym->name),sym->addr);
-    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\">\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
+    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\"/>\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
     write_docattributes(log,sym);
     if (sym->tag!=0) {
       tagsym=find_tag_byval(sym->tag);
@@ -4608,7 +4610,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
     if (sym->ident!=iVARIABLE && sym->ident!=iARRAY)
       continue;
     fprintf(log,"\t\t<member name=\"F:%s\">\n",funcdisplayname(symname,sym->name));
-    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\">\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
+    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\"/>\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
     write_docattributes(log,sym);
     if (sym->tag!=0) {
       tagsym=find_tag_byval(sym->tag);
@@ -4664,7 +4666,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
     } /* for */
     /* ??? should also print an "array return" size */
     fprintf(log,")\">\n");
-    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\">\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
+    fprintf(log,"\t\t<location file=\"%s\" startline=\"%"PRIdC"\" endline=\"%"PRIdC"\"/>\n", get_sourcefile(sym->fnumber), sym->lnumber_decl, sym->lnumber_end);
     write_docattributes(log,sym);
     if (sym->tag!=0) {
       tagsym=find_tag_byval(sym->tag);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -7242,7 +7242,7 @@ static void dostate(void)
         length+=strlen(str);
       if ((doc=(char*)malloc(length*sizeof(char)))!=NULL) {
         do {
-          sprintf(doc,"<transition target=\"%s\"",state->name);
+          sprintf(doc,"\t\t\t<transition target=\"%s\"",state->name);
           if (listid>=0) {
             /* get the source state */
             stateindex=state_listitem(listid,listindex);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4453,35 +4453,9 @@ static void write_docattributes(FILE *log, symbol *sym)
 
 static void write_docstring(FILE *log,const char *string)
 {
-  int len;
-  const char *ptr;
-
   if (string==NULL)
     return;
-  while (*string<=' ' && *string!='\0')
-    string++;                 /* skip white space */
-  if (*string=='\0')
-    return;
-
-  assert(strchr(string,sDOCSEP)==NULL);
-  /* optionally wrap in "<summary>...</summary>", check whether this must happen */
-  if (*string!='<') {       /* wrap in "summary" */
-    len=0;
-    for (ptr=string; *ptr!='\0' && *ptr!='<' && *ptr!='.'; ptr++)
-      len++;
-    if (*ptr=='.')
-      len++;
-    assert(len>0);
-    fprintf(log,"\t\t\t<summary>%.*s</summary>\n",len,string);
-    string+=len;
-    while (*string<=' ' && *string!='\0')
-      string++;             /* skip white space */
-  } else {
-    len=0;
-  } /* if */
-
-  if (*string!='\0')
-    fprintf(log,"\t\t\t%s\n",string);
+  fprintf(log,"\t\t\t%s\n",string);
 }
 
 static void make_report(symbol *root,FILE *log,char *sourcefile)

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4378,14 +4378,6 @@ static char *xmlencode(char *dest,char *source)
       strcpy(ptr,"&amp;");
       ptr+=5;
       break;
-    case '\"':
-      strcpy(ptr,"&quot;");
-      ptr+=6;
-      break;
-    case '\'':
-      strcpy(ptr,"&apos;");
-      ptr+=6;
-      break;
     default:
       *ptr++=*source;
     } /* switch */
@@ -4456,6 +4448,7 @@ static void write_docattributes(FILE *log, symbol *sym)
       fprintf(log,"\t\t\t<attribute name=\"static\"/>\n");
   }
 }
+
 static void write_docstring(FILE *log,const char *string)
 {
   int len;
@@ -4577,7 +4570,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
       if ((ref=sym->refer[i])!=NULL)
         fprintf(log,"\t\t\t<referrer name=\"%s\"/>\n",xmlencode(symname,funcdisplayname(symname,ref->name)));
     } /* for */
-    write_docstring(log,ref->documentation);
+    write_docstring(log,sym->documentation);
     fprintf(log,"\t\t</member>\n");
   } /* for */
 
@@ -7269,7 +7262,6 @@ static void dostate(void)
   #endif
   delete_autolisttable();
 }
-
 
 static void addwhile(int *ptr)
 {

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -500,7 +500,7 @@ static void stripcomment(unsigned char *line)
              * to the global documentation
              */
             if (curfunc==NULL && get_docstring(0)!=NULL)
-              sc_attachdocumentation(NULL);
+              sc_attachdocumentation(NULL,FALSE);
             icomment=2; /* documentation comment */
           } /* if */
           commentidx=0;
@@ -525,7 +525,7 @@ static void stripcomment(unsigned char *line)
              * block to the global documentation
              */
             if (!singleline && curfunc==NULL && get_docstring(0)!=NULL)
-              sc_attachdocumentation(NULL);
+              sc_attachdocumentation(NULL,FALSE);
             insert_docstring(str);
             prev_singleline=TRUE;
           } /* if */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2987,7 +2987,7 @@ static symbol *find_symbol(const symbol *root,const char *name,int fnumber,int a
   while (sym!=NULL) {
     if ( (is_global || strcmp(name,sym->name)==0)           /* check name */
         && (sym->parent==NULL || sym->ident==iCONSTEXPR)    /* sub-types (hierarchical types) are skipped, except for enum fields */
-        && (sym->fnumber<0 || sym->fnumber==fnumber))       /* check file number for scope */
+        && (!(sym->usage&uSTATIC) || sym->fnumber==fnumber))       /* check file number for scope */
     {
       assert(sym->states==NULL || sym->states->next!=NULL); /* first element of the state list is the "root" */
       if (sym->ident==iFUNCTN

--- a/xml/pawndoc.xsl
+++ b/xml/pawndoc.xsl
@@ -84,6 +84,7 @@
 				<h3>Depends on</h3>
 				<ul><xsl:apply-templates select="dependency"/></ul>
 			</xsl:if>
+			<xsl:apply-templates select="location"/>
 			<xsl:if test="seealso">
 				<h3>See Also</h3>
 				<ul><xsl:apply-templates select="seealso"/></ul>
@@ -108,6 +109,7 @@
 				<h3>Depends on</h3>
 				<ul><xsl:apply-templates select="dependency"/></ul>
 			</xsl:if>
+			<xsl:apply-templates select="location"/>
 			<xsl:if test="seealso">
 				<h3>See Also</h3>
 				<ul><xsl:apply-templates select="seealso"/></ul>
@@ -135,6 +137,7 @@
 				<h3>Depends on</h3>
 				<ul><xsl:apply-templates select="dependency"/></ul>
 			</xsl:if>
+			<xsl:apply-templates select="location"/>
 			<xsl:if test="attribute">
 				<h3>Attributes</h3>
 				<ul><xsl:apply-templates select="attribute"/></ul>
@@ -172,6 +175,7 @@
 				<h3>Depends on</h3>
 				<ul><xsl:apply-templates select="dependency"/></ul>
 			</xsl:if>
+			<xsl:apply-templates select="location"/>
 			<xsl:if test="seealso">
 				<h3>See Also</h3>
 				<ul><xsl:apply-templates select="seealso"/></ul>
@@ -212,6 +216,11 @@
 <xsl:template match="returns">
 	<h3>Returns</h3>
 	<p><xsl:apply-templates/></p>
+</xsl:template>
+
+<xsl:template match="location">
+	<h3>Defined in</h3>
+	<p><xsl:value-of select="@file"/>, line <xsl:value-of select="@startline"/> to <xsl:value-of select="@endline"/></p>
 </xsl:template>
 
 <xsl:template match="remarks">


### PR DESCRIPTION
- [x] Add `location` tag `<location file="" startline="" endline="">`
- [x] Fix `transition` tag
- [ ] Escape special characters in documentation
- [x] Fix enumerators documentation
- [x] Fix constant documentation
- [x] Add documentation for enumerators items
- [x] Add new atributes for member
	+ [x] const
	+ [x] deprecated
	+ [x] entry
	+ [x] enum
	+ [x] enum_field
	+ [x] forward
	+ [x] missing
	+ [x] naked
	+ [x] native
	+ [x] pre_defined
	+ [x] prototyped
	+ [x] public
	+ [x] returns
	+ [ ] return_type
	+ [x] static
	+ [x] stock
	+ [x] unused
- [x] Update `pawndoc.xsl` to support new features
- [ ] Fix a bug, when you documentate one prototype without keyword `forward` the documentation go to global