### PR TITLE
debug info for index tagmm warnings

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -566,6 +566,7 @@ long pc_lengthbin(void *handle); /* return the length of the file */
 SC_FUNC void set_extension(char *filename,char *extension,int force);
 SC_FUNC symbol *fetchfunc(char *name,int tag);
 SC_FUNC char *operator_symname(char *symname,char *opername,int tag1,int tag2,int numtags,int resulttag);
+SC_FUNC void check_index_tagmismatch(char *symname,int expectedtag,int actualtag,int allowcoerce,int errline);
 SC_FUNC void check_tagmismatch(int formaltag,int actualtag,int allowcoerce,int errline);
 SC_FUNC void check_tagmismatch_multiple(int formaltags[],int numtags,int actualtag,int errline);
 SC_FUNC char *funcdisplayname(char *dest,char *funcname);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3410,6 +3410,28 @@ static constvalue *find_tag_byval(int tag)
   return tagsym;
 }
 
+SC_FUNC void check_index_tagmismatch(char *symname,int expectedtag,int actualtag,int allowcoerce,int errline)
+{
+  assert(symname!=NULL);
+  if (!matchtag(expectedtag,actualtag,allowcoerce)) {
+    constvalue *tagsym;
+    char expected_tagname[sNAMEMAX+3]="none (\"_\"),",actual_tagname[sNAMEMAX+2]="none (\"_\")"; /* two extra characters for quotes */  
+    if(expectedtag!=0) {
+      tagsym=find_tag_byval(expectedtag);
+      sprintf(expected_tagname,"\"%s\",",(tagsym!=NULL) ? tagsym->name : "-unknown-");
+    } /* if */
+    if(actualtag!=0) {
+      tagsym=find_tag_byval(actualtag);
+      sprintf(actual_tagname,"\"%s\"",(tagsym!=NULL) ? tagsym->name : "-unknown-");
+    } /* if */
+    if(errline>0)
+      errorset(sSETPOS,errline);
+    error(229,symname,expected_tagname,actual_tagname); /* index tag mismatch */
+    if(errline>0)
+      errorset(sSETPOS,-1);    
+  } /* if */
+}
+
 SC_FUNC void check_tagmismatch(int formaltag,int actualtag,int allowcoerce,int errline)
 {
   if (!matchtag(formaltag,actualtag,allowcoerce)) {
@@ -3417,7 +3439,7 @@ SC_FUNC void check_tagmismatch(int formaltag,int actualtag,int allowcoerce,int e
     char formal_tagname[sNAMEMAX+3]="none (\"_\"),",actual_tagname[sNAMEMAX+2]="none (\"_\")"; /* two extra characters for quotes */  
     if(formaltag!=0) {
       tagsym=find_tag_byval(formaltag);
-      sprintf(formal_tagname,"\"%s\",", (tagsym!=NULL) ? tagsym->name : "-unknown-");
+      sprintf(formal_tagname,"\"%s\",",(tagsym!=NULL) ? tagsym->name : "-unknown-");
     } /* if */
     if(actualtag!=0) {
       tagsym=find_tag_byval(actualtag);

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1014,8 +1014,8 @@ static int hier14(value *lval1)
       return error(48); /* array dimensions must match */
     else if (ltlength<val || (exactmatch && ltlength>val) || val==0)
       return error(47); /* array sizes must match */
-    else if (lval3.ident!=iARRAYCELL && !matchtag(lval3.sym->x.tags.index,idxtag,TRUE))
-      error(229,(lval2.sym!=NULL) ? lval2.sym->name : lval3.sym->name); /* index tag mismatch */
+    else if (lval3.ident!=iARRAYCELL)
+      check_index_tagmismatch((lval2.sym!=NULL) ? lval2.sym->name : lval3.sym->name,lval3.sym->x.tags.index,idxtag,TRUE,0);
     if (level>0) {
       /* check the sizes of all sublevels too */
       symbol *sym1 = lval3.sym;
@@ -1036,8 +1036,8 @@ static int hier14(value *lval1)
          */
         if (sym1->dim.array.length!=sym2->dim.array.length)
           error(47);    /* array sizes must match */
-        else if (!matchtag(sym1->x.tags.index,sym2->x.tags.index,TRUE))
-          error(229,sym2->name);  /* index tag mismatch */
+        else
+          check_index_tagmismatch(sym2->name,sym1->x.tags.index,sym2->x.tags.index,TRUE,0);
       } /* for */
       /* get the total size in cells of the multi-dimensional array */
       val=array_totalsize(lval3.sym);
@@ -2250,8 +2250,8 @@ static int nesting=0;
               assert(level<sDIMEN_MAX);
               if (arg[argidx].dim[level]!=0 && sym->dim.array.length!=arg[argidx].dim[level])
                 error(47);        /* array sizes must match */
-              else if (!matchtag(arg[argidx].idxtag[level],sym->x.tags.index,TRUE))
-                error(229,sym->name);   /* index tag mismatch */
+              else
+                check_index_tagmismatch(sym->name,arg[argidx].idxtag[level],sym->x.tags.index,TRUE,0);
               append_constval(&arrayszlst,arg[argidx].name,sym->dim.array.length,level);
               sym=finddepend(sym);
               assert(sym!=NULL);
@@ -2262,8 +2262,8 @@ static int nesting=0;
             assert(sym!=NULL);
             if (arg[argidx].dim[level]!=0 && sym->dim.array.length!=arg[argidx].dim[level])
               error(47);          /* array sizes must match */
-            else if (!matchtag(arg[argidx].idxtag[level],sym->x.tags.index,TRUE))
-              error(229,sym->name);   /* index tag mismatch */
+            else
+              check_index_tagmismatch(sym->name,arg[argidx].idxtag[level],sym->x.tags.index,TRUE,0);
             append_constval(&arrayszlst,arg[argidx].name,sym->dim.array.length,level);
           } /* if */
           /* address already in PRI */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -183,7 +183,7 @@ static char *warnmsg[] = {
 /*226*/  "a variable is assigned to itself (symbol \"%s\")\n",
 /*227*/  "more initiallers than enum fields\n",
 /*228*/  "length of initialler exceeds size of the enum field\n",
-/*229*/  "index tag mismatch (symbol \"%s\")\n",
+/*229*/  "index tag mismatch (symbol \"%s\"): expected tag %s but found %s\n",
 /*230*/  "no implementation for state \"%s\" in function \"%s\", no fall-back\n",
 /*231*/  "state specification on forward declaration is ignored\n",
 /*232*/  "output file is written, but with compact encoding disabled\n",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the compiler display debug information for "index" tag mismatch warnings.

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

**Test Code:**
```
f1(arr[EFG:100]) {
	#pragma unused arr
}
f2(arr[100]) {
	#pragma unused arr
}
main() {
	new arr0[100];
	f1(arr0);

	new arr1[ABC:100];
	f1(arr1);
	
	new arr2[klm:100];
	f2(arr2); /* weak tag -> no tag ===> no warning */
}
```

**Output:**
```
warning 229: index tag mismatch (symbol "arr0"): expected tag "EFG", but found none ("_")
warning 229: index tag mismatch (symbol "arr1"): expected tag "EFG", but found "ABC"
```