### PR TITLE
destructor not implemented error

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4967,6 +4967,14 @@ static void destructsymbols(symbol *root,int level)
       /* check that the '~' operator is defined for this tag */
       operator_symname(symbolname,"~",sym->tag,0,1,0);
       if ((opsym=findglb(symbolname,sGLOBAL))!=NULL) {
+        if ((opsym->usage & uMISSING)!=0 || (opsym->usage & uPROTOTYPED)==0) {
+          char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
+          funcdisplayname(symname,opsym->name);
+          if ((opsym->usage & uMISSING)!=0)
+            error(4,symname);           /* function not defined */
+          if ((opsym->usage & uPROTOTYPED)==0)
+            error(71,symname);          /* operator must be declared before use */
+        } /* if */
         /* save PRI, in case of a return statment */
         if (!savepri) {
           pushreg(sPRI);        /* right-hand operand is in PRI */

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -70,6 +70,12 @@ set_tests_properties(const_array_args_and_literals_gh_276 PROPERTIES PASS_REGULA
 .*\\.pwn\\(41\\) : warning 239: literal array/string passed to a non-const parameter
 ")
 
+add_compiler_test(destructor_not_impl_gh_310 ${CMAKE_CURRENT_SOURCE_DIR}/destructor_not_impl_gh_310.pwn)
+set_tests_properties(destructor_not_impl_gh_310 PROPERTIES PASS_REGULAR_EXPRESSION
+".*\\.pwn\\(6\\) : error 004: function \"operator~(Error:)\" is not implemented
+")
+set_tests_properties(destructor_not_impl_gh_310 PROPERTIES WILL_FAIL TRUE)
+
 # Crashers
 #
 # These tests simply check that the compiler doesn't crash.

--- a/source/compiler/tests/destructor_not_impl_gh_310.pwn
+++ b/source/compiler/tests/destructor_not_impl_gh_310.pwn
@@ -1,0 +1,4 @@
+forward operator~(Error:right[], size);
+main() {
+    new Error:e;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

```
#include <a_samp>

forward operator~(Error:right[], size);
main() {
    new Error:e;
}
```

```
CODE 0    ; 0
;program exit point
    halt 0

    proc    ; main
    ; line 4
    ; line 5
    break    ; c
    ;$lcl e fffffffc
    push.c 0
    ;$exp
    push.pri
    push.c 1
    addr.pri fffffffc
    push.pri
    push.c 8
    call .~4000000f    ; operator~(Error:)
    pop.pri
    stack 4
    zero.pri
    retn

STKSIZE 1000
```

The compiler tries to call a non-existent function. This commit instead throws "function not implemented" error when destructor definition is missing.

`error 004: function "operator~(Error:)" is not implemented`

**Which issue(s) this PR fixes**:

Fixes #310 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

