### PR TITLE
fix result propagation in constexpr operator chains

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -512,6 +512,7 @@ static int plnge_rel(int *opstr,int opoff,int (*hier)(value *lval),value *lval)
       error(212);
     if (count>0) {
       relop_prefix();
+      lval2.boolresult=lval->boolresult;
       *lval=lval2;      /* copy right hand expression of the previous iteration */
     } /* if */
     opidx+=opoff;

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -52,6 +52,14 @@ set_tests_properties(meaningless_class_specifiers_gh_172 PROPERTIES PASS_REGULAR
 .*\\.pwn\\(1 \\-\\- 2\\) : warning 238: meaningless combination of class specifiers \\(const variable arguments\\)
 ")
 
+add_compiler_test(constexpr_result_prop_gh_308 ${CMAKE_CURRENT_SOURCE_DIR}/constexpr_result_prop_gh_308.pwn)
+set_tests_properties(constexpr_result_prop_gh_308 PROPERTIES PASS_REGULAR_EXPRESSION
+".*\\.pwn\\(2\\) : warning 237: user warning: \\\"Test passed.\\\"
+.*\\.pwn\\(6\\) : warning 237: user warning: \\\"Test passed.\\\"
+.*\\.pwn\\(10\\) : warning 237: user warning: \\\"Test passed.\\\"
+.*\\.pwn\\(14\\) : warning 237: user warning: \\\"Test passed.\\\"
+")
+
 # Crashers
 #
 # These tests simply check that the compiler doesn't crash.

--- a/source/compiler/tests/constexpr_result_prop_gh_308.pwn
+++ b/source/compiler/tests/constexpr_result_prop_gh_308.pwn
@@ -1,0 +1,19 @@
+#if (30 < 40 < 50)
+	#warning "Test passed."
+#endif
+
+#if !(30 < 40 < 35)
+	#warning "Test passed."
+#endif
+
+#if (30 < 40)
+	#warning "Test passed."
+#endif
+
+#if !(40 < 35)
+	#warning "Test passed."
+#endif
+
+main () {
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The compiler fails to propagate the result of chained operations through the entire chain.

`15 < 20 < 30` evaluates to false even though it is true.

This PR resolves the above issue.

Refer to the commit description and https://github.com/pawn-lang/compiler/issues/308#issuecomment-395941341 for details.

**Which issue(s) this PR fixes**:

Fixes #308 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other
