### PR TITLE
check dimensions of uninitialized array declarations

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2490,17 +2490,21 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
   cell tablesize;
   int curlit=litidx;
   int err=0;
+  int i;
 
   if (!matchtoken('=')) {
     assert(ident!=iARRAY || numdim>0);
-    if (ident==iARRAY && dim[numdim-1]==0) {
-      /* declared as "myvar[];" which is senseless (note: this *does* make
-       * sense in the case of a iREFARRAY, which is a function parameter)
-       */
-      error(9);         /* array has zero length -> invalid size */
-    } /* if */
     if (ident==iARRAY) {
       assert(numdim>0 && numdim<=sDIMEN_MAX);
+      for (i=0; i<numdim; i++) {
+        if (dim[i]==0) {
+          /* declared like "myvar[];" which is senseless (note: this *does* make
+           * sense in the case of a iREFARRAY, which is a function parameter)
+           */
+          error(9); /* array has zero length -> invalid size */
+          return;
+        } /* if */
+      } /* for */      
       *size=calc_arraysize(dim,numdim,0);
       if (*size==(cell)CELL_MAX) {
         error(9);       /* array is too big -> invalid size */

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -70,6 +70,16 @@ set_tests_properties(const_array_args_and_literals_gh_276 PROPERTIES PASS_REGULA
 .*\\.pwn\\(41\\) : warning 239: literal array/string passed to a non-const parameter
 ")
 
+add_compiler_test(md_array_size_chk_gh_314 ${CMAKE_CURRENT_SOURCE_DIR}/md_array_size_chk_gh_314.pwn)
+set_tests_properties(md_array_size_chk_gh_314 PROPERTIES PASS_REGULAR_EXPRESSION
+"*\\.pwn\\(1\\) : error 009: invalid array size \\(negative, zero or out of bounds\\)
+.*\\.pwn\\(2\\) : error 009: invalid array size \\(negative, zero or out of bounds\\)
+.*\\.pwn\\(3\\) : error 009: invalid array size \\(negative, zero or out of bounds\\)
+.*\\.pwn\\(5\\) : error 009: invalid array size \\(negative, zero or out of bounds\\)
+.*\\.pwn\\(30\\) : warning 224: indeterminate array size in \"sizeof\" expression \\(symbol \"\"\\)
+")
+set_tests_properties(md_array_size_chk_gh_314 PROPERTIES WILL_FAIL TRUE)
+
 # Crashers
 #
 # These tests simply check that the compiler doesn't crash.

--- a/source/compiler/tests/md_array_size_chk_gh_314.pwn
+++ b/source/compiler/tests/md_array_size_chk_gh_314.pwn
@@ -1,0 +1,40 @@
+new arr1[] = {};
+new arr2[5][];
+new arr3[5][][5];
+new arr4[5][5];
+new arr5[][]= { { } };
+
+f1(arr[]) {
+	#pragma unused arr
+}
+f2(arr[5][]) {
+	#pragma unused arr
+}
+f3(arr[5][][5]) {
+	#pragma unused arr
+}
+f4(arr[5][5]) {
+	#pragma unused arr
+}
+f5(arr[][]) {
+	#pragma unused arr
+}
+
+main () {
+	arr1[0] = 0;
+	arr2[0][0] = 0;
+	arr3[0][0][0] = 0;
+	arr4[0][0] = 0;
+	arr5[0][0] = 0;
+
+	new a = sizeof(arr1);
+	a = sizeof(arr1[]);
+	a = sizeof(arr5[][]);
+	#pragma unused a
+
+	f1(arr1);
+	f2(arr2);
+	f3(arr3);
+	f4(arr4);
+	f5(arr5);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The compiler crashes while processing meaningless array declarations where the size of one of the dimensions is not specified. This PR adds code to trigger an error.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #314

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other