### PR TITLE
fix various issues associated with i276 and pr302

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4223,8 +4223,12 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
     assert(numtags>0);
     argsym=addvariable(name,offset,ident,sLOCAL,tags[0],
                        arg->dim,arg->numdim,arg->idxtag,0);
-    if (fpublic)
+    if (fpublic) {
       argsym->usage|=uREAD;     /* arguments of public functions are always "used" */
+      if(argsym->ident==iREFARRAY || argsym->ident==iREFERENCE)
+        argsym->usage|=uWRITTEN;
+    }
+      
     if (fconst)
       argsym->usage|=uCONST;
   } /* if */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4907,9 +4907,20 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
         error(204,sym->name);       /* value assigned to symbol is never used */
         errorset(sSETPOS,-1);
       } else if ((sym->usage & (uWRITTEN | uPUBLIC | uCONST))==0 && sym->ident==iREFARRAY) {
-        errorset(sSETPOS,sym->lnumber);
-        error(214,sym->name);       /* make array argument "const" */
-        errorset(sSETPOS,-1);
+        int warn = 1;
+        symbol* depend = finddepend(sym);
+        while (depend != NULL) {
+          if ((depend->usage & (uWRITTEN | uPUBLIC | uCONST)) != 0) {
+            warn = 0;
+            break;
+          }
+          depend = finddepend(depend);
+        } /* while */
+        if (warn) {
+          errorset(sSETPOS, sym->lnumber);
+          error(214, sym->name);       /* make array argument "const" */
+          errorset(sSETPOS, -1);
+        } /* if */
       } /* if */
       /* also mark the variable (local or global) to the debug information */
       if ((sym->usage & (uWRITTEN | uREAD))!=0 && (sym->usage & uNATIVE)==0)

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2215,7 +2215,7 @@ static int nesting=0;
             if (arg[argidx].numdim!=1) {
               error(48);        /* array dimensions must match */
             } else {
-              if (lval.sym==NULL && (arg[argidx].usage & uCONST)==0)
+              if (lval.sym==NULL && (arg[argidx].usage & uCONST)==0 && (sym->usage & uNATIVE)==0)
                     error(239);
               if (arg[argidx].dim[0]!=0) {
                 assert(arg[argidx].dim[0]>0);

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -52,6 +52,16 @@ set_tests_properties(meaningless_class_specifiers_gh_172 PROPERTIES PASS_REGULAR
 .*\\.pwn\\(1 \\-\\- 2\\) : warning 238: meaningless combination of class specifiers \\(const variable arguments\\)
 ")
 
+add_compiler_test(const_array_args_and_literals_gh_276 ${CMAKE_CURRENT_SOURCE_DIR}/const_array_args_and_literals_gh_276.pwn)
+set_tests_properties(const_array_args_and_literals_gh_276 PROPERTIES PASS_REGULAR_EXPRESSION
+".*\\.pwn\\(13\\) : warning 214: possibly a \\\"const\\\" array argument was intended: \\\"arr\\\"
+.*\\.pwn\\(18\\) : warning 214: possibly a \\\"const\\\" array argument was intended: \\\"arr\\\"
+.*\\.pwn\\(30\\) : warning 214: possibly a \\\"const\\\" array argument was intended: \\\"arr\\\"
+.*\\.pwn\\(39\\) : warning 239: literal array/string passed to a non-const parameter
+.*\\.pwn\\(40\\) : warning 239: literal array/string passed to a non-const parameter
+.*\\.pwn\\(41\\) : warning 239: literal array/string passed to a non-const parameter
+")
+
 # Crashers
 #
 # These tests simply check that the compiler doesn't crash.

--- a/source/compiler/tests/const_array_args_and_literals_gh_276.pwn
+++ b/source/compiler/tests/const_array_args_and_literals_gh_276.pwn
@@ -1,0 +1,61 @@
+forward OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+
+native SetTimer(funcname[], interval, repeating);
+public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+
+}
+
+f0(arr[]) {
+	#pragma unused arr
+}
+
+f1(arr[]) { // line 13
+ 	new a = arr[0];
+ 	#pragma unused a
+}
+
+f2(arr[5]) {// line 18
+	new a = arr[0];
+    #pragma unused a
+}
+f3(const arr[]) {
+    new a = arr[0];
+    #pragma unused a
+}
+f4(const arr[5]) {
+    new a = arr[0];
+    #pragma unused a
+}
+f5(arr[][]) { // line 30
+	new a = arr[0][0];
+	#pragma unused a
+}
+f6(arr[][]) {
+	arr[0][0] = 0;
+}
+
+main () {
+	f0("test"); // line 39
+	f1("test"); // line 40
+	f2("test"); // line 41
+	f3("test");
+	f4("test");
+
+	new arr[5];
+	f1(arr);
+	f2(arr);
+	f3(arr);
+	f4(arr);
+
+	f1(arr[0]);
+	//f2(arr[0]); - array size must match
+	f3(arr[0]);
+	//f4(arr[0]); - array size must match
+
+	new arr2[1][1];
+	f5(arr2);
+	f6(arr2);
+
+	SetTimer("test", 0, 0);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Original PR:
- suggest `const` qualifier for arguments if the symbol is not modified (excluding its depends)
- trigger a warning if a literal is being passed to a non-const qualified parameter

This PR:
- do not suggest `const` qualifier for parameters of `public` functions
- do not trigger literal being passed to non-const qualified parameter warning for arguments passed to native functions
- check if depends are modified for array arguments of functions before suggesting `const` qualifier

What's allowed now:
- suggest `const` for all non-native and non-public functions if the argument is not modified
- warn if a literal is passed to non-const qualified parameter (including publics) of non-native functions


**Which issue(s) this PR fixes**:

Fixes #276 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

```
forward OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);

native SetTimer(funcname[], interval, repeating);
public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
{

}

f0(arr[]) {
	#pragma unused arr
}

f1(arr[]) { // line 13
 	new a = arr[0];
 	#pragma unused a
}

f2(arr[5]) {// line 18
	new a = arr[0];
    #pragma unused a
}
f3(const arr[]) {
    new a = arr[0];
    #pragma unused a
}
f4(const arr[5]) {
    new a = arr[0];
    #pragma unused a
}
f5(arr[][]) { // line 30
	new a = arr[0][0]; 
	#pragma unused a
}
f6(arr[][]) {
	arr[0][0] = 0;
}

main () {
	f0("test"); // line 39
	f1("test"); // line 40
	f2("test"); // line 41
	f3("test");
	f4("test");

	new arr[5];
	f1(arr);
	f2(arr);
	f3(arr);
	f4(arr);

	f1(arr[0]);
	//f2(arr[0]); - array size must match
	f3(arr[0]);
	//f4(arr[0]); - array size must match

	new arr2[1][1];
	f5(arr2);
	f6(arr2);

	SetTimer("test", 0, 0);
}
```

```
test.pwn(13) : warning 214: possibly a "const" array argument was intended: "arr"
test.pwn(18) : warning 214: possibly a "const" array argument was intended: "arr"
test.pwn(30) : warning 214: possibly a "const" array argument was intended: "arr"
test.pwn(39) : warning 239: literal array/string passed to a non-const parameter
test.pwn(40) : warning 239: literal array/string passed to a non-const parameter
test.pwn(41) : warning 239: literal array/string passed to a non-const parameter
Pawn compiler 3.10.7	 	 	Copyright (c) 1997-2006, ITB CompuPhase


6 Warnings.

```
