### PR TITLE
use enum for defining tokens

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -345,9 +345,8 @@ enum {
   tDEC,   /* -- */
   tELLIPS,  /* ... */
   tDBLDOT,  /* .. */
-  tDBLCOLON, /* :: */
 
-  tMIDDLE = tDBLCOLON, /* value of last multi-character operator */
+  tMIDDLE = tDBLDOT, /* value of last multi-character operator */
 
   /* reserved words (statements) */
   tASSERT,

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -421,10 +421,7 @@ enum {
   teLOCAL, /* local variable (name or offset) */
   teFUNCTN, /* Pawn function */
   teNATIVE, /* native function */
-  teNONNEG, /* nonnegative integer */
-
-  tlexLAST = teNONNEG,
-
+  teNONNEG , /* nonnegative integer */
   /* for assigment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -421,7 +421,10 @@ enum {
   teLOCAL, /* local variable (name or offset) */
   teFUNCTN, /* Pawn function */
   teNATIVE, /* native function */
-  teNONNEG , /* nonnegative integer */
+  teNONNEG, /* nonnegative integer */
+
+  tlexLAST = teNONNEG,
+
   /* for assigment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -396,7 +396,7 @@ enum {
   tpERROR,
   tpFILE,
   tpIF,/* #if */
-  tINCLUDE,
+  tpINCLUDE,
   tpLINE,
   tpPRAGMA,
   tpTRYINCLUDE,

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -188,7 +188,7 @@ typedef struct s_symbol {
 
 /*  Possible entries for "usage"
  *
- *  This byte is used as a serie of bits, the syntax is different for
+ *  This byte is used as a series of bits, the syntax is different for
  *  functions and other symbols:
  *
  *  VARIABLE
@@ -317,108 +317,116 @@ typedef struct s_valuepair {
 /*  Tokens recognized by lex()
  *  Some of these constants are assigned as well to the variable "lastst" (see SC1.C)
  */
-#define tFIRST      256 /* value of first multi-character operator */
-#define tMIDDLE     280 /* value of last multi-character operator */
-#define tLAST       331 /* value of last multi-character match-able token */
-/* multi-character operators */
-#define taMULT      256 /* *= */
-#define taDIV       257 /* /= */
-#define taMOD       258 /* %= */
-#define taADD       259 /* += */
-#define taSUB       260 /* -= */
-#define taSHL       261 /* <<= */
-#define taSHRU      262 /* >>>= */
-#define taSHR       263 /* >>= */
-#define taAND       264 /* &= */
-#define taXOR       265 /* ^= */
-#define taOR        266 /* |= */
-#define tlOR        267 /* || */
-#define tlAND       268 /* && */
-#define tlEQ        269 /* == */
-#define tlNE        270 /* != */
-#define tlLE        271 /* <= */
-#define tlGE        272 /* >= */
-#define tSHL        273 /* << */
-#define tSHRU       274 /* >>> */
-#define tSHR        275 /* >> */
-#define tINC        276 /* ++ */
-#define tDEC        277 /* -- */
-#define tELLIPS     278 /* ... */
-#define tDBLDOT     279 /* .. */
-#define tDBLCOLON   280 /* :: */
-/* reserved words (statements) */
-#define tASSERT     281
-#define tBEGIN      282
-#define tBREAK      283
-#define tCASE       284
-#define tCHAR       285
-#define tCONST      286
-#define tCONTINUE   287
-#define tDEFAULT    288
-#define tDEFINED    289
-#define tDO         290
-#define tELSE       291
-#define tEMIT       292
-#define t__EMIT     293
-#define tEND        294
-#define tENUM       295
-#define tEXIT       296
-#define tFOR        297
-#define tFORWARD    298
-#define tGOTO       299
-#define tIF         300
-#define tNATIVE     301
-#define tNEW        302
-#define tOPERATOR   303
-#define tPUBLIC     304
-#define tRETURN     305
-#define tSIZEOF     306
-#define tSLEEP      307
-#define tSTATE      308
-#define tSTATIC     309
-#define tSTOCK      310
-#define tSWITCH     311
-#define tTAGOF      312
-#define tTHEN       313
-#define tWHILE      314
-/* compiler directives */
-#define tpASSERT    315 /* #assert */
-#define tpDEFINE    316
-#define tpELSE      317 /* #else */
-#define tpELSEIF    318 /* #elseif */
-#define tpEMIT      319
-#define tpENDIF     320
-#define tpENDINPUT  321
-#define tpENDSCRPT  322
-#define tpERROR     323
-#define tpFILE      324
-#define tpIF        325 /* #if */
-#define tINCLUDE    326
-#define tpLINE      327
-#define tpPRAGMA    328
-#define tpTRYINCLUDE 329
-#define tpUNDEF     330
-#define tpWARNING   331
-/* semicolon is a special case, because it can be optional */
-#define tTERM       332 /* semicolon or newline */
-#define tENDEXPR    333 /* forced end of expression */
-/* other recognized tokens */
-#define tNUMBER     334 /* integer number */
-#define tRATIONAL   335 /* rational number */
-#define tSYMBOL     336
-#define tLABEL      337
-#define tSTRING     338
-/* argument types for emit/__emit */
-#define teANY       339 /* any value */
-#define teNUMERIC   340 /* integer/rational number */
-#define teDATA      341 /* data (variable name or address) */
-#define teLOCAL     342 /* local variable (name or offset) */
-#define teFUNCTN    343 /* Pawn function */
-#define teNATIVE    344 /* native function */
-#define teNONNEG    345 /* nonnegative integer */
-/* for assigment to "lastst" only (see SC1.C) */
-#define tEXPR       346
-#define tENDLESS    347 /* endless loop */
+enum {
+  /* multi-character operators */
+  tFIRST  = 256,  /* value of first multi-character operator */
+
+  taMULT  =  tFIRST,  /* *= */
+  taDIV,  /* /= */
+  taMOD,  /* %= */
+  taADD,  /* += */
+  taSUB,  /* -= */
+  taSHL,  /* <<= */
+  taSHRU, /* >>>= */
+  taSHR,  /* >>= */
+  taAND,  /* &= */
+  taXOR,  /* ^= */
+  taOR,   /* |= */
+  tlOR,   /* || */
+  tlAND,  /* && */
+  tlEQ,   /* == */
+  tlNE,   /* != */
+  tlLE,   /* <= */
+  tlGE,   /* >= */
+  tSHL,   /* << */
+  tSHRU,  /* >>> */
+  tSHR,   /* >> */
+  tINC,   /* ++ */
+  tDEC,   /* -- */
+  tELLIPS,  /* ... */
+  tDBLDOT,  /* .. */
+  tDBLCOLON, /* :: */
+
+  tMIDDLE = tDBLCOLON, /* value of last multi-character operator */
+
+  /* reserved words (statements) */
+  tASSERT,
+  tBEGIN,
+  tBREAK,
+  tCASE,
+  tCHAR,
+  tCONST,
+  tCONTINUE,
+  tDEFAULT,
+  tDEFINED,
+  tDO,
+  tELSE,
+  tEMIT,
+  t__EMIT,
+  tEND,
+  tENUM,
+  tEXIT,
+  tFOR,
+  tFORWARD,
+  tGOTO,
+  tIF,
+  tNATIVE,
+  tNEW,
+  tOPERATOR,
+  tPUBLIC,
+  tRETURN,
+  tSIZEOF,
+  tSLEEP,
+  tSTATE,
+  tSTATIC,
+  tSTOCK,
+  tSWITCH,
+  tTAGOF,
+  tTHEN,
+  tWHILE,
+
+  /* compiler directives */
+  tpASSERT, /* #assert */
+  tpDEFINE,
+  tpELSE, /* #else */
+  tpELSEIF, /* #elseif */
+  tpEMIT,
+  tpENDIF,
+  tpENDINPUT,
+  tpENDSCRPT,
+  tpERROR,
+  tpFILE,
+  tpIF,/* #if */
+  tINCLUDE,
+  tpLINE,
+  tpPRAGMA,
+  tpTRYINCLUDE,
+  tpUNDEF,
+  tpWARNING,
+
+  tLAST = tpWARNING, /* value of last multi-character match-able token */
+
+  /* semicolon is a special case, because it can be optional */
+  tTERM,/* semicolon or newline */
+  tENDEXPR, /* forced end of expression */
+  /* other recognized tokens */
+  tNUMBER,/* integer number */
+  tRATIONAL, /* rational number */
+  tSYMBOL,
+  tLABEL,
+  tSTRING,
+  /* argument types for emit/__emit */
+  teANY , /* any value */
+  teNUMERIC, /* integer/rational number */
+  teDATA  , /* data (variable name or address) */
+  teLOCAL, /* local variable (name or offset) */
+  teFUNCTN, /* Pawn function */
+  teNATIVE, /* native function */
+  teNONNEG , /* nonnegative integer */
+  /* for assigment to "lastst" only (see SC1.C) */
+  tEXPR,
+  tENDLESS, /* endless loop */
+};
 
 /* (reversed) evaluation of staging buffer */
 #define sSTARTREORDER 0x01

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -238,7 +238,7 @@ typedef struct s_symbol {
  */
 #define uRETNONE    0x10
 
-#define flgDEPRECATED 0x01  /* symbol is deprecated (avoid use) */
+#define flagDEPRECATED 0x01  /* symbol is deprecated (avoid use) */
 #define flagNAKED     0x10  /* function is naked */
 #define flagPREDEF    0x20  /* symbol is pre-defined; successor of uPREDEF */
 

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3171,7 +3171,7 @@ SC_FUNC symbol *fetchfunc(char *name,int tag)
   } /* if */
   if (pc_deprecate!=NULL) {
     assert(sym!=NULL);
-    sym->flags|=flgDEPRECATED;
+    sym->flags|=flagDEPRECATED;
     if (sc_status==statWRITE) {
       if (sym->documentation!=NULL) {
         free(sym->documentation);
@@ -3785,7 +3785,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
     cidx=code_idx;
     glbdecl=glb_declared;
   } /* if */
-  if ((sym->flags & flgDEPRECATED)!=0) {
+  if ((sym->flags & flagDEPRECATED)!=0) {
     char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
     error(234,symbolname,ptr);  /* deprecated (probably a public function) */
   } /* if */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1082,7 +1082,7 @@ static int command(void)
     } /* if */
     check_empty(lptr);
     break;
-  case tINCLUDE:                /* #include directive */
+  case tpINCLUDE:                /* #include directive */
   case tpTRYINCLUDE:
     ret=CMD_INCLUDE;
     if (!SKIPPING)

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2133,7 +2133,7 @@ SC_FUNC void lexinit(void)
   _lexnewline=FALSE;
 }
 
-char *sc_tokens[] = {
+char *sc_tokens[tlexLAST-tFIRST+1] = {
          "*=", "/=", "%=", "+=", "-=", "<<=", ">>>=", ">>=", "&=", "^=", "|=",
          "||", "&&", "==", "!=", "<=", ">=", "<<", ">>>", ">>", "++", "--",
          "...", "..",

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2133,7 +2133,7 @@ SC_FUNC void lexinit(void)
   _lexnewline=FALSE;
 }
 
-char *sc_tokens[tlexLAST-tFIRST+1] = {
+char *sc_tokens[] = {
          "*=", "/=", "%=", "+=", "-=", "<<=", ">>>=", ">>=", "&=", "^=", "|=",
          "||", "&&", "==", "!=", "<=", ">=", "<<", ">>>", ">>", "++", "--",
          "...", "..",

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2136,7 +2136,7 @@ SC_FUNC void lexinit(void)
 char *sc_tokens[] = {
          "*=", "/=", "%=", "+=", "-=", "<<=", ">>>=", ">>=", "&=", "^=", "|=",
          "||", "&&", "==", "!=", "<=", ">=", "<<", ">>>", ">>", "++", "--",
-         "...", "..", "::",
+         "...", "..",
          "assert", "*begin", "break", "case", "char", "const", "continue", "default",
          "defined", "do", "else", "emit", "__emit", "*end", "enum", "exit", "for",
          "forward", "goto", "if", "native", "new", "operator", "public", "return",

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2031,7 +2031,7 @@ static int nesting=0;
   #endif
   sc_allowproccall=FALSE;       /* parameters may not use procedure call syntax */
 
-  if ((sym->flags & flgDEPRECATED)!=0) {
+  if ((sym->flags & flagDEPRECATED)!=0) {
     char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
     error(234,sym->name,ptr);   /* deprecated (probably a native function) */
   } /* if */


### PR DESCRIPTION
**What this PR does / why we need it**:

The old system used a series of `#define`s to assign a value to each token. The compiler does not use the values directly but requires the tokens values to be unique.

The problem arises when a new token has to be added. The tokens are sorted alphabetically. To maintain the consistency of the order, the developer needs to add his token somewhere in the middle (in most cases) and offset the rest of the entries by one. Not just that, the developer would also have to update `tLAST`. This is highly error-prone.

With this PR, the developer would just have to insert his token somewhere and the remaining values would automatically adjust themselves.

**What kind of pull this is**:

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [x] Other
