### PR TITLE
Use `pragma deprecated` message in error 4.

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5010,8 +5010,9 @@ static void destructsymbols(symbol *root,int level)
         if ((opsym->usage & uMISSING)!=0 || (opsym->usage & uPROTOTYPED)==0) {
           char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
           funcdisplayname(symname,opsym->name);
+          char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
           if ((opsym->usage & uMISSING)!=0)
-            error(4,symname);           /* function not defined */
+            error(4,symname,ptr);       /* function not defined */
           if ((opsym->usage & uPROTOTYPED)==0)
             error(71,symname);          /* operator must be declared before use */
         } /* if */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5009,8 +5009,8 @@ static void destructsymbols(symbol *root,int level)
       if ((opsym=findglb(symbolname,sGLOBAL))!=NULL) {
         if ((opsym->usage & uMISSING)!=0 || (opsym->usage & uPROTOTYPED)==0) {
           char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-          funcdisplayname(symname,opsym->name);
           char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
+          funcdisplayname(symname,opsym->name);
           if ((opsym->usage & uMISSING)!=0)
             error(4,symname,ptr);       /* function not defined */
           if ((opsym->usage & uPROTOTYPED)==0)

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -195,8 +195,9 @@ static void (*unopers[])(void) = { lneg, neg, user_inc, user_dec };
   if ((sym->usage & uMISSING)!=0 || (sym->usage & uPROTOTYPED)==0) {
     char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
     funcdisplayname(symname,sym->name);
+    char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
     if ((sym->usage & uMISSING)!=0)
-      error(4,symname);           /* function not defined */
+      error(4,symname,ptr);       /* function not defined */
     if ((sym->usage & uPROTOTYPED)==0)
       error(71,symname);          /* operator must be declared before use */
   } /* if */
@@ -1880,7 +1881,8 @@ restart:
       } else if ((sym->usage & uMISSING)!=0) {
         char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
         funcdisplayname(symname,sym->name);
-        error(4,symname);             /* function not defined */
+        char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
+        error(4,symname,ptr);         /* function not defined */
       } /* if */
       callfunction(sym,lval1,TRUE);
       return FALSE;             /* result of function call is no lvalue */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -194,8 +194,8 @@ static void (*unopers[])(void) = { lneg, neg, user_inc, user_dec };
   /* check existance and the proper declaration of this function */
   if ((sym->usage & uMISSING)!=0 || (sym->usage & uPROTOTYPED)==0) {
     char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-    funcdisplayname(symname,sym->name);
     char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
+    funcdisplayname(symname,sym->name);
     if ((sym->usage & uMISSING)!=0)
       error(4,symname,ptr);       /* function not defined */
     if ((sym->usage & uPROTOTYPED)==0)
@@ -1880,8 +1880,8 @@ restart:
         } /* if */
       } else if ((sym->usage & uMISSING)!=0) {
         char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-        funcdisplayname(symname,sym->name);
         char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
+        funcdisplayname(symname,sym->name);
         error(4,symname,ptr);         /* function not defined */
       } /* if */
       callfunction(sym,lval1,TRUE);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -43,7 +43,7 @@ static char *errmsg[] = {
 /*001*/  "expected token: \"%s\", but found \"%s\"\n",
 /*002*/  "only a single statement (or expression) can follow each \"case\"\n",
 /*003*/  "declaration of a local variable must appear in a compound block\n",
-/*004*/  "function \"%s\" is not implemented\n",
+/*004*/  "function \"%s\" is not implemented %s\n",
 /*005*/  "function may not have arguments\n",
 /*006*/  "must be assigned to an array\n",
 /*007*/  "operator cannot be redefined\n",

--- a/source/compiler/tests/gh_500.meta
+++ b/source/compiler/tests/gh_500.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_500.pwn(13) : error 004: function "Test1" is not implemented - use "Test4"
+gh_500.pwn(14) : error 004: function "Test2" is not implemented 
+gh_500.pwn(15) : error 004: function "Test3" is not implemented 
+"""
+}

--- a/source/compiler/tests/gh_500.pwn
+++ b/source/compiler/tests/gh_500.pwn
@@ -1,0 +1,16 @@
+#pragma deprecated - use "Test4"
+forward Test1();
+
+#pragma deprecated
+forward Test2();
+
+forward Test3();
+
+stock Test4(){}
+
+main()
+{
+	Test1(); // error 004: function "Test1" is not implemented - use "Test4"
+	Test2(); // error 004: function "Test2" is not implemented
+	Test3(); // error 004: function "Test3" is not implemented
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

```pawn
#pragma deprecated - use "Test2".
forward Test();

stock Test2() { }

main()
{
	Test();
}
```

When `#pragma deprecated` is used on an unimplemented forwarded function, calling it will append the deprecation message to the error.  This gives a four tier method to removing functions:

1. Deprecated.
2. Deprecated and unimplemented.
3. Unimplemented.
4. Removed.

The example above will give:

```
error 004: function "Test" is not implemented - use "Test2".
```

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
