### PR TITLE
[MERGED] Fix `break` and `continue` not calling destructors properly

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -265,6 +265,8 @@ enum {
   wqCONT,       /* used to restore stack for "continue" */
   wqLOOP,       /* loop start label number */
   wqEXIT,       /* loop exit label number (jump if false) */
+  wqLVL,        /* "compound statement" nesting level for the loop body
+                 * (used to call destructors for "break" and "continue") */
   /* --- */
   wqSIZE        /* "while queue" size */
 };

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5820,6 +5820,7 @@ static int dofor(void)
   assert(ptr!=NULL);
   ptr[wqBRK]=(int)declared;
   ptr[wqCONT]=(int)declared;
+  ptr[wqLVL]=nestlevel+1;
   jumplabel(skiplab);               /* skip expression 3 1st time */
   setlabel(wq[wqLOOP]);             /* "continue" goes to this label: expr3 */
   setline(TRUE);
@@ -7769,7 +7770,7 @@ static void dobreak(void)
   needtoken(tTERM);
   if (ptr==NULL)
     return;
-  destructsymbols(&loctab,nestlevel);
+  destructsymbols(&loctab,ptr[wqLVL]);
   modstk(((int)declared-ptr[wqBRK])*sizeof(cell));
   jumplabel(ptr[wqEXIT]);
 }
@@ -7782,7 +7783,7 @@ static void docont(void)
   needtoken(tTERM);
   if (ptr==NULL)
     return;
-  destructsymbols(&loctab,nestlevel);
+  destructsymbols(&loctab,ptr[wqLVL]);
   modstk(((int)declared-ptr[wqCONT])*sizeof(cell));
   jumplabel(ptr[wqLOOP]);
 }
@@ -7948,6 +7949,7 @@ static void addwhile(int *ptr)
   ptr[wqCONT]=(int)declared;    /* for "continue", possibly adjusted later */
   ptr[wqLOOP]=getlabel();
   ptr[wqEXIT]=getlabel();
+  ptr[wqLVL]=nestlevel+1;
   if (wqptr>=(wq+wqTABSZ-wqSIZE))
     error(102,"loop table");    /* loop table overflow (too many active loops)*/
   k=0;

--- a/source/compiler/tests/gh_531.meta
+++ b/source/compiler/tests/gh_531.meta
@@ -1,0 +1,77 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  nop
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.c 00000002
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.c 00000003
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000008
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  nop
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  nop
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  nop
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  zero.pri
+[0-9a-f]+  retn
+"""
+}

--- a/source/compiler/tests/gh_531.pwn
+++ b/source/compiler/tests/gh_531.pwn
@@ -1,0 +1,35 @@
+#pragma option -d0
+
+stock operator~(Tag:values[], count)
+{
+    #pragma unused values, count
+}
+
+main()
+{
+	static const bool:TRUE = true;
+	__emit nop;
+	while (TRUE)
+	{
+		new Tag:var2 = Tag:2;
+		if (TRUE)
+		{
+			new Tag:var3 = Tag:3;
+			if (TRUE)
+			{
+				break;
+			}
+		}
+	}
+
+	__emit nop;
+	new Tag:var1;
+	while (TRUE)
+		continue;
+
+	__emit nop;
+	for (new Tag:i = Tag:0; TRUE; )
+		continue;
+
+	__emit nop;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `break` and `continue` not calling destructors properly in certain situations (see #531 for details).

**Which issue(s) this PR fixes**:

Fixes #531

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: