### PR TITLE
[MERGED] Further improvements for detection of unused assignments

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -957,6 +957,7 @@ SC_VDECL int pc_memflags;     /* special flags for the stack/heap usage */
 SC_VDECL int pc_naked;        /* if true mark following function as naked */
 SC_VDECL int pc_compat;       /* running in compatibility mode? */
 SC_VDECL int pc_recursion;    /* enable detailed recursion report? */
+SC_VDECL int pc_nestlevel;    /* number of active (open) compound statements */
 
 SC_VDECL constvalue_root sc_automaton_tab; /* automaton table */
 SC_VDECL constvalue_root sc_state_tab;     /* state table */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -701,7 +701,6 @@ SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom);
 SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
 SC_FUNC void clearassignments(symbol *root,int fromlevel);
-SC_FUNC void demoteassignments(symbol* root,int level);
 SC_FUNC void memoizeassignments(symbol *root,int fromlevel,assigninfo **assignments);
 SC_FUNC void restoreassignments(symbol *root,int fromlevel,assigninfo *assignments);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -691,6 +691,7 @@ SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom);
 SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
 SC_FUNC void clearassignments(symbol *root,int fromlevel);
+SC_FUNC void demoteassignments(symbol* root,int level);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);
 SC_FUNC symbol *findglb(const char *name,int filter);
 SC_FUNC symbol *findloc(const char *name);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -700,9 +700,9 @@ SC_FUNC void delete_symbols(symbol *root,int level,int del_labels,int delete_fun
 SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom);
 SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
-SC_FUNC void clearassignments(symbol *root,int fromlevel);
-SC_FUNC void memoizeassignments(symbol *root,int fromlevel,assigninfo **assignments);
-SC_FUNC void restoreassignments(symbol *root,int fromlevel,assigninfo *assignments);
+SC_FUNC void clearassignments(int fromlevel);
+SC_FUNC void memoizeassignments(int fromlevel,assigninfo **assignments);
+SC_FUNC void restoreassignments(int fromlevel,assigninfo *assignments);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);
 SC_FUNC symbol *findglb(const char *name,int filter);
 SC_FUNC symbol *findloc(const char *name);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -690,7 +690,7 @@ SC_FUNC void delete_symbols(symbol *root,int level,int del_labels,int delete_fun
 SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom);
 SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
-SC_FUNC void clearassignments(symbol *root);
+SC_FUNC void clearassignments(symbol *root,int fromlevel);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);
 SC_FUNC symbol *findglb(const char *name,int filter);
 SC_FUNC symbol *findloc(const char *name);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -146,6 +146,7 @@ typedef struct s_symbol {
       short level;      /* number of dimensions below this level */
     } array;
   } dim;                /* for 'dimension', both functions and arrays */
+  int assignlevel;      /* 'compound statement' level at which the variable was assigned a value */
   constvalue_root *states;/* list of state function/state variable ids + addresses */
   int fnumber;          /* static global variables: file number in which the declaration is visible */
   int lnumber;          /* line number (in the current source file) for the declaration */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -301,6 +301,16 @@ typedef struct s_valuepair {
   long second;
 } valuepair;
 
+/* struct "assigninfo" is used to synchronize the status of assignments that
+ * were made in multiple "if" and "switch" branches, so the compiler could
+ * detect unused assignments in all of those branches, not only the last one */
+typedef struct s_assigninfo {
+  int unused;       /* true if the variable has an unused value assigned to it
+                     * in one of the branches" */
+  int lnumber;      /* line number of the first unused assignment made in one of
+                     * the branches (used for error messages) */
+} assigninfo;
+
 /* macros for code generation */
 #define opcodes(n)      ((n)*sizeof(cell))      /* opcode size */
 #define opargs(n)       ((n)*sizeof(cell))      /* size of typical argument */
@@ -692,6 +702,8 @@ SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
 SC_FUNC void clearassignments(symbol *root,int fromlevel);
 SC_FUNC void demoteassignments(symbol* root,int level);
+SC_FUNC void memoizeassignments(symbol *root,int fromlevel,assigninfo **assignments);
+SC_FUNC void restoreassignments(symbol *root,int fromlevel,assigninfo *assignments);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);
 SC_FUNC symbol *findglb(const char *name,int filter);
 SC_FUNC symbol *findloc(const char *name);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -265,6 +265,8 @@ enum {
   wqCONT,       /* used to restore stack for "continue" */
   wqLOOP,       /* loop start label number */
   wqEXIT,       /* loop exit label number (jump if false) */
+  wqLVL,        /* "compound statement" nesting level for the loop body
+                 * (used to call destructors for "break" and "continue") */
   /* --- */
   wqSIZE        /* "while queue" size */
 };

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5822,6 +5822,7 @@ static int dofor(void)
   assert(ptr!=NULL);
   ptr[wqBRK]=(int)declared;
   ptr[wqCONT]=(int)declared;
+  ptr[wqLVL]=nestlevel+1;
   jumplabel(skiplab);               /* skip expression 3 1st time */
   setlabel(wq[wqLOOP]);             /* "continue" goes to this label: expr3 */
   setline(TRUE);
@@ -7771,7 +7772,7 @@ static void dobreak(void)
   needtoken(tTERM);
   if (ptr==NULL)
     return;
-  destructsymbols(&loctab,nestlevel);
+  destructsymbols(&loctab,ptr[wqLVL]);
   modstk(((int)declared-ptr[wqBRK])*sizeof(cell));
   jumplabel(ptr[wqEXIT]);
 }
@@ -7784,7 +7785,7 @@ static void docont(void)
   needtoken(tTERM);
   if (ptr==NULL)
     return;
-  destructsymbols(&loctab,nestlevel);
+  destructsymbols(&loctab,ptr[wqLVL]);
   modstk(((int)declared-ptr[wqCONT])*sizeof(cell));
   jumplabel(ptr[wqLOOP]);
 }
@@ -7950,6 +7951,7 @@ static void addwhile(int *ptr)
   ptr[wqCONT]=(int)declared;    /* for "continue", possibly adjusted later */
   ptr[wqLOOP]=getlabel();
   ptr[wqEXIT]=getlabel();
+  ptr[wqLVL]=nestlevel+1;
   if (wqptr>=(wq+wqTABSZ-wqSIZE))
     error(102,"loop table");    /* loop table overflow (too many active loops)*/
   k=0;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4314,6 +4314,7 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
         argsym->usage|=uWRITTEN;
     } else if (argsym->ident==iVARIABLE) {
       argsym->usage|=uASSIGNED;
+      argsym->assignlevel=1;
     } /* if */
 
     if (fconst)
@@ -5464,10 +5465,14 @@ static void statement(int *lastindent,int allow_decl)
   /* fallthrough */
   default:          /* non-empty expression */
     sc_allowproccall=optproccall;
+    if (!allow_decl)
+      pc_nestlevel++;
     lexpush();      /* analyze token later */
     doexpr(TRUE,TRUE,TRUE,TRUE,NULL,NULL,FALSE,NULL);
     needtoken(tTERM);
     lastst=tEXPR;
+    if (!allow_decl)
+      pc_nestlevel--;
     sc_allowproccall=FALSE;
   } /* switch */
 }

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5268,6 +5268,8 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag)
 redef_enumfield:
   sym=addsym(name,val,iCONSTEXPR,vclass,tag,uDEFINE);
   assert(sym!=NULL);            /* fatal error 103 must be given on error */
+  if (vclass==sLOCAL)
+    sym->compound=nestlevel;
   return sym;
 }
 

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5703,18 +5703,20 @@ static int doif(void)
   if (!matchtoken(tELSE)) {     /* if...else ? */
     setlabel(flab1);            /* no, simple if..., print false label */
   } else {
+    assigninfo *assignments=NULL;
     lastst_true=lastst;         /* save last statement of the "true" branch */
     /* to avoid the "dangling else" error, we want a warning if the "else"
      * has a lower indent than the matching "if" */
     if (stmtindent<ifindent && sc_tabsize>0)
       error(217);               /* loose indentation */
-    clearassignments(&loctab,pc_nestlevel+1);
+    memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
     flab2=getlabel();
     if ((lastst!=tRETURN) && (lastst!=tGOTO))
       jumplabel(flab2);         /* "true" branch jumps around "else" clause, unless the "true" branch statement already jumped */
     setlabel(flab1);            /* print false label */
     statement(NULL,FALSE);      /* do "else" clause */
     setlabel(flab2);            /* print true label */
+    restoreassignments(&loctab,pc_nestlevel+1,assignments);
     /* if both the "true" branch and the "false" branch ended with the same
      * kind of statement, set the last statement id to that kind, rather than
      * to the generic tIF; this allows for better "unreachable code" checking

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5905,6 +5905,7 @@ static void doswitch(void)
   constvalue_root caselist = { NULL, NULL};   /* case list starts empty */
   constvalue *cse,*csp,*newval;
   char labelname[sNAMEMAX+1];
+  assigninfo *assignments=NULL;
 
   endtok= matchtoken('(') ? ')' : tDO;
   doexpr(TRUE,FALSE,FALSE,FALSE,&swtag,NULL,TRUE,NULL);/* evaluate switch expression */
@@ -5930,7 +5931,7 @@ static void doswitch(void)
     switch (tok) {
     case tCASE:
       if (casecount!=0)
-        clearassignments(&loctab,pc_nestlevel+1);
+        memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)
         error(15);        /* "default" case must be last in switch statement */
       lbl_case=getlabel();
@@ -5999,7 +6000,7 @@ static void doswitch(void)
       break;
     case tDEFAULT:
       if (casecount!=0)
-        clearassignments(&loctab,pc_nestlevel+1);
+        memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)
         error(16);         /* multiple defaults in switch */
       lbl_case=getlabel();
@@ -6021,6 +6022,7 @@ static void doswitch(void)
       } /* if */
     } /* switch */
   } while (tok!=endtok);
+  restoreassignments(&loctab,pc_nestlevel+1,assignments);
   demoteassignments(&loctab,pc_nestlevel);
 
   #if !defined NDEBUG

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5101,14 +5101,6 @@ static void destructsymbols(symbol *root,int level)
         if ((opsym->usage & uNATIVE)!=0 && opsym->x.lib!=NULL)
           opsym->x.lib->value += 1; /* increment "usage count" of the library */
       } /* if */
-      /* check that the assigned value was used, but don't show the warning
-       * if the variable is completely unused (we already have warning 203 for that) */
-      if ((sym->usage & (uASSIGNED | uREAD | uWRITTEN))==(uASSIGNED | uREAD | uWRITTEN)
-          && sym->vclass!=sSTATIC) {
-        errorset(sSETPOS,sym->lnumber);
-        error(204,sym->name);   /* symbol is assigned a value that is never used */
-        errorset(sSETPOS,-1);
-    } /* if */
     } /* if */
     sym=sym->next;
   } /* while */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5722,6 +5722,7 @@ static int doif(void)
     if (lastst==lastst_true)
       return lastst;
   } /* if */
+  demoteassignments(&loctab,pc_nestlevel);
   return tIF;
 }
 
@@ -6009,6 +6010,7 @@ static void doswitch(void)
       } /* if */
     } /* switch */
   } while (tok!=endtok);
+  demoteassignments(&loctab,pc_nestlevel);
 
   #if !defined NDEBUG
     /* verify that the case table is sorted (unfortunatly, duplicates can

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2379,7 +2379,6 @@ static int declloc(int fstatic)
         explicit_init=FALSE;
         if (matchtoken('=')) {
           int initexpr_ident;
-          cell val;
           sym->usage &= ~uDEFINE;   /* temporarily mark the variable as undefined to prevent
                                      * possible self-assignment through its initialization expression */
           initexpr_ident=doexpr(FALSE,FALSE,FALSE,FALSE,&ctag,NULL,TRUE,&val);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5101,6 +5101,8 @@ static void destructsymbols(symbol *root,int level)
         if ((opsym->usage & uNATIVE)!=0 && opsym->x.lib!=NULL)
           opsym->x.lib->value += 1; /* increment "usage count" of the library */
       } /* if */
+    } else if (level==0 && sym->ident==iREFERENCE) {
+      sym->usage &= ~uASSIGNED;
     } /* if */
     sym=sym->next;
   } /* while */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -7773,6 +7773,7 @@ static void dobreak(void)
   if (ptr==NULL)
     return;
   destructsymbols(&loctab,ptr[wqLVL]);
+  clearassignments(&loctab);
   modstk(((int)declared-ptr[wqBRK])*sizeof(cell));
   jumplabel(ptr[wqEXIT]);
 }
@@ -7786,6 +7787,7 @@ static void docont(void)
   if (ptr==NULL)
     return;
   destructsymbols(&loctab,ptr[wqLVL]);
+  clearassignments(&loctab);
   modstk(((int)declared-ptr[wqCONT])*sizeof(cell));
   jumplabel(ptr[wqLOOP]);
 }

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5811,7 +5811,6 @@ static int dofor(void)
       /* The variable in expr1 of the for loop is at a
        * 'compound statement' level of it own.
        */
-      pc_nestlevel++;
       declloc(FALSE); /* declare local variable */
     } else {
       doexpr(TRUE,TRUE,TRUE,TRUE,NULL,NULL,FALSE,NULL); /* expression 1 */
@@ -5862,8 +5861,8 @@ static int dofor(void)
   setlabel(wq[wqEXIT]);
   delwhile();
 
-  assert(pc_nestlevel>=save_nestlevel+1);
-  if (pc_nestlevel>save_nestlevel+1) {
+  assert(pc_nestlevel>save_nestlevel);
+  if (declared>save_decl) {
     /* Clean up the space and the symbol table for the local
      * variable in "expr1".
      */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5697,6 +5697,7 @@ static int doif(void)
   int ifindent;
   int lastst_true;
   int returnst=tIF;
+  assigninfo *assignments=NULL;
 
   ifindent=stmtindent;          /* save the indent of the "if" instruction */
   flab1=getlabel();             /* get label number for false branch */
@@ -5705,7 +5706,6 @@ static int doif(void)
   if (!matchtoken(tELSE)) {     /* if...else ? */
     setlabel(flab1);            /* no, simple if..., print false label */
   } else {
-    assigninfo *assignments=NULL;
     lastst_true=lastst;         /* save last statement of the "true" branch */
     /* to avoid the "dangling else" error, we want a warning if the "else"
      * has a lower indent than the matching "if" */
@@ -5718,7 +5718,6 @@ static int doif(void)
     setlabel(flab1);            /* print false label */
     statement(NULL,FALSE);      /* do "else" clause */
     setlabel(flab2);            /* print true label */
-    restoreassignments(&loctab,pc_nestlevel+1,assignments);
     /* if both the "true" branch and the "false" branch ended with the same
      * kind of statement, set the last statement id to that kind, rather than
      * to the generic tIF; this allows for better "unreachable code" checking
@@ -5726,7 +5725,7 @@ static int doif(void)
     if (lastst==lastst_true)
       returnst=lastst;
   } /* if */
-  demoteassignments(&loctab,pc_nestlevel);
+  restoreassignments(&loctab,pc_nestlevel+1,assignments);
   return returnst;
 }
 
@@ -6025,7 +6024,6 @@ static void doswitch(void)
     } /* switch */
   } while (tok!=endtok);
   restoreassignments(&loctab,pc_nestlevel+1,assignments);
-  demoteassignments(&loctab,pc_nestlevel);
 
   #if !defined NDEBUG
     /* verify that the case table is sorted (unfortunatly, duplicates can

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5694,6 +5694,7 @@ static int doif(void)
   int flab1,flab2;
   int ifindent;
   int lastst_true;
+  int returnst=tIF;
 
   ifindent=stmtindent;          /* save the indent of the "if" instruction */
   flab1=getlabel();             /* get label number for false branch */
@@ -5719,10 +5720,10 @@ static int doif(void)
      * to the generic tIF; this allows for better "unreachable code" checking
      */
     if (lastst==lastst_true)
-      return lastst;
+      returnst=lastst;
   } /* if */
   demoteassignments(&loctab,pc_nestlevel);
-  return tIF;
+  return returnst;
 }
 
 static int dowhile(void)

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5711,7 +5711,7 @@ static int doif(void)
      * has a lower indent than the matching "if" */
     if (stmtindent<ifindent && sc_tabsize>0)
       error(217);               /* loose indentation */
-    memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
+    memoizeassignments(pc_nestlevel+1,&assignments);
     flab2=getlabel();
     if ((lastst!=tRETURN) && (lastst!=tGOTO))
       jumplabel(flab2);         /* "true" branch jumps around "else" clause, unless the "true" branch statement already jumped */
@@ -5725,7 +5725,7 @@ static int doif(void)
     if (lastst==lastst_true)
       returnst=lastst;
   } /* if */
-  restoreassignments(&loctab,pc_nestlevel+1,assignments);
+  restoreassignments(pc_nestlevel+1,assignments);
   return returnst;
 }
 
@@ -5748,7 +5748,7 @@ static int dowhile(void)
   endlessloop=test(wq[wqEXIT],TEST_DO,FALSE);/* branch to wq[wqEXIT] if false */
   pc_nestlevel--;
   statement(NULL,FALSE);        /* if so, do a statement */
-  clearassignments(&loctab,pc_nestlevel+1);
+  clearassignments(pc_nestlevel+1);
   jumplabel(wq[wqLOOP]);        /* and loop to "while" start */
   setlabel(wq[wqEXIT]);         /* exit label */
   delwhile();                   /* delete queue entry */
@@ -5780,7 +5780,7 @@ static int dodo(void)
                    * could be cleaned up later */
   endlessloop=test(wq[wqEXIT],TEST_OPT,FALSE);
   pc_nestlevel--;
-  clearassignments(&loctab,pc_nestlevel+1);
+  clearassignments(pc_nestlevel+1);
   jumplabel(top);
   setlabel(wq[wqEXIT]);
   delwhile();
@@ -5860,7 +5860,7 @@ static int dofor(void)
   stgout(index);
   stgset(FALSE);                    /* stop staging */
   statement(NULL,FALSE);
-  clearassignments(&loctab,save_nestlevel+1);
+  clearassignments(save_nestlevel+1);
   jumplabel(wq[wqLOOP]);
   setlabel(wq[wqEXIT]);
   delwhile();
@@ -5932,7 +5932,7 @@ static void doswitch(void)
     switch (tok) {
     case tCASE:
       if (casecount!=0)
-        memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
+        memoizeassignments(pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)
         error(15);        /* "default" case must be last in switch statement */
       lbl_case=getlabel();
@@ -6001,7 +6001,7 @@ static void doswitch(void)
       break;
     case tDEFAULT:
       if (casecount!=0)
-        memoizeassignments(&loctab,pc_nestlevel+1,&assignments);
+        memoizeassignments(pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)
         error(16);         /* multiple defaults in switch */
       lbl_case=getlabel();
@@ -6023,7 +6023,7 @@ static void doswitch(void)
       } /* if */
     } /* switch */
   } while (tok!=endtok);
-  restoreassignments(&loctab,pc_nestlevel+1,assignments);
+  restoreassignments(pc_nestlevel+1,assignments);
 
   #if !defined NDEBUG
     /* verify that the case table is sorted (unfortunatly, duplicates can
@@ -6086,7 +6086,7 @@ static void dogoto(void)
   if (lex(&val,&st)==tSYMBOL) {
     sym=fetchlab(st);
     if ((sym->usage & uDEFINE)!=0)
-      clearassignments(&loctab,1);
+      clearassignments(1);
     jumplabel((int)sym->addr);
     sym->usage|=uREAD;  /* set "uREAD" bit */
     // ??? if the label is defined (check sym->usage & uDEFINE), check
@@ -7784,7 +7784,7 @@ static void dobreak(void)
   if (ptr==NULL)
     return;
   destructsymbols(&loctab,ptr[wqLVL]);
-  clearassignments(&loctab,1);
+  clearassignments(1);
   modstk(((int)declared-ptr[wqBRK])*sizeof(cell));
   jumplabel(ptr[wqEXIT]);
 }
@@ -7798,7 +7798,7 @@ static void docont(void)
   if (ptr==NULL)
     return;
   destructsymbols(&loctab,ptr[wqLVL]);
-  clearassignments(&loctab,1);
+  clearassignments(1);
   modstk(((int)declared-ptr[wqCONT])*sizeof(cell));
   jumplabel(ptr[wqLOOP]);
 }

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3211,11 +3211,11 @@ SC_FUNC void markusage(symbol *sym,int usage)
 SC_FUNC void markinitialized(symbol *sym,int assignment)
 {
   assert(sym!=NULL);
-  if (sym->ident!=iVARIABLE && sym->ident!=iARRAY)
+  if (sym->ident!=iVARIABLE && sym->ident!=iREFERENCE && sym->ident!=iARRAY)
     return;
   if (sc_status==statFIRST && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
     return;
-  if (assignment && sym->ident==iVARIABLE) {
+  if (assignment && (sym->ident==iVARIABLE || sym->ident==iREFERENCE)) {
     sym->usage |= uASSIGNED;
     sym->assignlevel=pc_nestlevel;
   } /* if */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3215,8 +3215,10 @@ SC_FUNC void markinitialized(symbol *sym,int assignment)
     return;
   if (sc_status==statFIRST && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
     return;
-  if (assignment && sym->ident==iVARIABLE)
+  if (assignment && sym->ident==iVARIABLE) {
     sym->usage |= uASSIGNED;
+    sym->assignlevel=pc_nestlevel;
+  } /* if */
 }
 
 SC_FUNC void clearassignments(symbol *root)
@@ -3328,6 +3330,7 @@ SC_FUNC symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,i
   entry.ident=(char)ident;
   entry.tag=tag;
   entry.usage=(char)usage;
+  entry.assignlevel=0;
   entry.fnumber=-1;     /* assume global visibility (ignored for local symbols) */
   entry.lnumber=fline;
   entry.numrefers=1;

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1013,7 +1013,7 @@ static int command(void)
     iflevel++;
     if (SKIPPING)
       break;                    /* break out of switch */
-    clearassignments(&loctab);
+    clearassignments(&loctab,1);
     skiplevel=iflevel;
     preproc_expr(&val,NULL);    /* get value (or 0 on error) */
     ifstack[iflevel-1]=(char)(val ? PARSEMODE : SKIPMODE);
@@ -1053,7 +1053,7 @@ static int command(void)
           } /* if */
         } else {
           /* previous conditions were all FALSE */
-          clearassignments(&loctab);
+          clearassignments(&loctab,1);
           if (tok==tpELSEIF) {
             /* if we were already skipping this section, allow expressions with
              * undefined symbols; otherwise check the expression to catch errors
@@ -1080,7 +1080,7 @@ static int command(void)
       error(26);        /* no matching "#if" */
       errorset(sRESET,0);
     } else {
-      clearassignments(&loctab);
+      clearassignments(&loctab,1);
       iflevel--;
       if (iflevel<skiplevel)
         skiplevel=iflevel;
@@ -3221,7 +3221,8 @@ SC_FUNC void markinitialized(symbol *sym,int assignment)
   } /* if */
 }
 
-SC_FUNC void clearassignments(symbol *root)
+/* clears assignments starting from the specified 'compound statement' nesting level and higher */
+SC_FUNC void clearassignments(symbol *root,int fromlevel)
 {
   symbol *sym;
 
@@ -3230,10 +3231,10 @@ SC_FUNC void clearassignments(symbol *root)
   if (sc_status!=statWRITE)
     return;
 
-  /* clear the unused assignment flag for all variables in the table */
   sym=root;
   while ((sym=sym->next)!=NULL)
-    sym->usage &= ~uASSIGNED;
+    if (sym->assignlevel>=fromlevel)
+      sym->usage &= ~uASSIGNED;
 }
 
 

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3003,6 +3003,15 @@ SC_FUNC void delete_symbols(symbol *root,int level,int delete_labels,int delete_
       mustdelete=delete_labels;
       break;
     case iVARIABLE:
+      /* check that the assigned value was used, but don't show the warning
+       * if the variable is completely unused (we already have warning 203 for that) */
+      if ((sym->usage & (uASSIGNED | uREAD | uWRITTEN))==(uASSIGNED | uREAD | uWRITTEN)
+          && sym->vclass==sLOCAL) {
+        errorset(sSETPOS,sym->lnumber);
+        error(204,sym->name);   /* symbol is assigned a value that is never used */
+        errorset(sSETPOS,-1);
+      } /* if */
+      /* fallthrough */
     case iARRAY:
       /* do not delete global variables if functions are preserved */
       mustdelete=delete_functions;

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3237,6 +3237,22 @@ SC_FUNC void clearassignments(symbol *root,int fromlevel)
       sym->usage &= ~uASSIGNED;
 }
 
+/* demotes assignments to the specified 'compound statement' nesting level */
+SC_FUNC void demoteassignments(symbol* root,int level)
+{
+  symbol* sym;
+
+  /* the error messages are only printed on the "writing" pass,
+   * so if we are not writing yet, then we have a quick exit */
+  if (sc_status!=statWRITE)
+    return;
+
+  sym=root;
+  while ((sym=sym->next)!=NULL)
+    if (sym->assignlevel>level)
+      sym->assignlevel=level;
+}
+
 
 /*  findglb
  *

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3212,12 +3212,17 @@ SC_FUNC void markinitialized(symbol *sym,int assignment)
 
 SC_FUNC void clearassignments(symbol *root)
 {
+  symbol *sym;
+
+  /* the error messages are only printed on the "writing" pass,
+   * so if we are not writing yet, then we have a quick exit */
+  if (sc_status!=statWRITE)
+    return;
+
   /* clear the unused assignment flag for all variables in the table */
-  symbol *sym=root->next;
-  while (sym!=NULL) {
+  sym=root;
+  while ((sym=sym->next)!=NULL)
     sym->usage &= ~uASSIGNED;
-    sym=sym->next;
-  } /* while */
 }
 
 

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3215,7 +3215,7 @@ SC_FUNC void markinitialized(symbol *sym,int assignment)
     return;
   if (sc_status==statFIRST && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
     return;
-  if (assignment && (sym->ident==iVARIABLE || sym->ident==iREFERENCE)) {
+  if (assignment && sym->vclass!=sGLOBAL && (sym->ident==iVARIABLE || sym->ident==iREFERENCE)) {
     sym->usage |= uASSIGNED;
     sym->assignlevel=pc_nestlevel;
   } /* if */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1069,7 +1069,8 @@ static int hier14(value *lval1)
   if (oper==NULL) {
     symbol *sym=lval3.sym;
     assert(sym!=NULL);
-    if ((sym->usage & uASSIGNED)!=0 && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
+    if ((sym->usage & uASSIGNED)!=0 && sym->assignlevel>=pc_nestlevel
+        && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
       error(240,sym->name); /* previously assigned value is unused */
     markinitialized(sym,TRUE);
     if (pc_ovlassignment)

--- a/source/compiler/scvars.c
+++ b/source/compiler/scvars.c
@@ -97,6 +97,7 @@ SC_VDEFINE int pc_memflags=0;               /* special flags for the stack/heap 
 SC_VDEFINE int pc_naked=FALSE;              /* if true mark following function as naked */
 SC_VDEFINE int pc_compat=FALSE;             /* running in compatibility mode? */
 SC_VDEFINE int pc_recursion=FALSE;          /* enable detailed recursion report? */
+SC_VDEFINE int pc_nestlevel=0;              /* number of active (open) compound statements */
 
 SC_VDEFINE constvalue_root sc_automaton_tab = { NULL, NULL}; /* automaton table */
 SC_VDEFINE constvalue_root sc_state_tab = { NULL, NULL};   /* state table */

--- a/source/compiler/tests/gh_531.meta
+++ b/source/compiler/tests/gh_531.meta
@@ -1,0 +1,77 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  nop
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.c 00000002
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.c 00000003
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000008
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  nop
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  nop
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffff8
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  nop
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000001
+[0-9a-f]+  addr.pri fffffffc
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  stack 00000004
+[0-9a-f]+  zero.pri
+[0-9a-f]+  retn
+"""
+}

--- a/source/compiler/tests/gh_531.pwn
+++ b/source/compiler/tests/gh_531.pwn
@@ -1,0 +1,35 @@
+#pragma option -d0
+
+stock operator~(Tag:values[], count)
+{
+    #pragma unused values, count
+}
+
+main()
+{
+	static const bool:TRUE = true;
+	__emit nop;
+	while (TRUE)
+	{
+		new Tag:var2 = Tag:2;
+		if (TRUE)
+		{
+			new Tag:var3 = Tag:3;
+			if (TRUE)
+			{
+				break;
+			}
+		}
+	}
+
+	__emit nop;
+	new Tag:var1;
+	while (TRUE)
+		continue;
+
+	__emit nop;
+	for (new Tag:i = Tag:0; TRUE; )
+		continue;
+
+	__emit nop;
+}

--- a/source/compiler/tests/gh_541.meta
+++ b/source/compiler/tests/gh_541.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_541.pwn(21) : error 017: undefined symbol "CONSTVAL"
+gh_541.pwn(22) : error 017: undefined symbol "ENUM_ITEM1"
+  """
+}

--- a/source/compiler/tests/gh_541.pwn
+++ b/source/compiler/tests/gh_541.pwn
@@ -1,0 +1,23 @@
+main()
+{
+	new const bool:TRUE = true;
+	if (TRUE)
+	{
+		const CONSTVAL = 0;
+		enum
+		{
+			ENUM_ITEM1
+		};
+		if (TRUE)
+		{
+			return CONSTVAL;
+		}
+		if (TRUE)
+		{
+			return ENUM_ITEM1;
+		}
+	}
+	if (TRUE)
+		return CONSTVAL; // error 017: undefined symbol "CONSTVAL"
+	return ENUM_ITEM1; // error 017: undefined symbol "ENUM_ITEM1"
+}

--- a/source/compiler/tests/warning_240.meta
+++ b/source/compiler/tests/warning_240.meta
@@ -4,15 +4,16 @@
 warning_240.pwn(11) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(12) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(14) : warning 204: symbol is assigned a value that is never used: "local_var"
-warning_240.pwn(31) : warning 204: symbol is assigned a value that is never used: "local_var2"
+warning_240.pwn(27) : warning 240: previously assigned value is never used (symbol "local_var2")
+warning_240.pwn(32) : warning 204: symbol is assigned a value that is never used: "local_var2"
 warning_240.pwn(25) : warning 204: symbol is assigned a value that is never used: "local_var"
-warning_240.pwn(53) : warning 204: symbol is assigned a value that is never used: "local_var2"
-warning_240.pwn(63) : warning 240: previously assigned value is never used (symbol "local_static_var")
+warning_240.pwn(54) : warning 204: symbol is assigned a value that is never used: "local_var2"
 warning_240.pwn(64) : warning 240: previously assigned value is never used (symbol "local_static_var")
-warning_240.pwn(89) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(90) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(90) : warning 204: symbol is assigned a value that is never used: "arg"
-warning_240.pwn(96) : warning 204: symbol is assigned a value that is never used: "arg"
-warning_240.pwn(103) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(65) : warning 240: previously assigned value is never used (symbol "local_static_var")
+warning_240.pwn(92) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(93) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(93) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(99) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(106) : warning 204: symbol is assigned a value that is never used: "arg"
 """
 }

--- a/source/compiler/tests/warning_240.meta
+++ b/source/compiler/tests/warning_240.meta
@@ -4,15 +4,19 @@
 warning_240.pwn(12) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(14) : warning 204: symbol is assigned a value that is never used: "local_var"
 warning_240.pwn(38) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(46) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(57) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(68) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(87) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(96) : warning 240: previously assigned value is never used (symbol "local_static_var")
-warning_240.pwn(122) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(126) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(131) : warning 240: previously assigned value is never used (symbol "refarg")
-warning_240.pwn(126) : warning 204: symbol is assigned a value that is never used: "arg"
-warning_240.pwn(160) : warning 204: symbol is assigned a value that is never used: "local_var"
+warning_240.pwn(52) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(66) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(74) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(85) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(97) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(109) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(120) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(139) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(148) : warning 240: previously assigned value is never used (symbol "local_static_var")
+warning_240.pwn(174) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(178) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(183) : warning 240: previously assigned value is never used (symbol "refarg")
+warning_240.pwn(178) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(212) : warning 204: symbol is assigned a value that is never used: "local_var"
 """
 }

--- a/source/compiler/tests/warning_240.meta
+++ b/source/compiler/tests/warning_240.meta
@@ -1,19 +1,18 @@
 {
   'test_type': 'output_check',
   'errors': """
-warning_240.pwn(11) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(12) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(14) : warning 204: symbol is assigned a value that is never used: "local_var"
-warning_240.pwn(27) : warning 240: previously assigned value is never used (symbol "local_var2")
-warning_240.pwn(32) : warning 204: symbol is assigned a value that is never used: "local_var2"
-warning_240.pwn(25) : warning 204: symbol is assigned a value that is never used: "local_var"
-warning_240.pwn(54) : warning 204: symbol is assigned a value that is never used: "local_var2"
-warning_240.pwn(64) : warning 240: previously assigned value is never used (symbol "local_static_var")
-warning_240.pwn(65) : warning 240: previously assigned value is never used (symbol "local_static_var")
-warning_240.pwn(92) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(93) : warning 240: previously assigned value is never used (symbol "arg")
-warning_240.pwn(93) : warning 204: symbol is assigned a value that is never used: "arg"
-warning_240.pwn(99) : warning 204: symbol is assigned a value that is never used: "arg"
-warning_240.pwn(106) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(38) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(46) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(57) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(68) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(87) : warning 240: previously assigned value is never used (symbol "local_var")
+warning_240.pwn(96) : warning 240: previously assigned value is never used (symbol "local_static_var")
+warning_240.pwn(122) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(126) : warning 240: previously assigned value is never used (symbol "arg")
+warning_240.pwn(131) : warning 240: previously assigned value is never used (symbol "refarg")
+warning_240.pwn(126) : warning 204: symbol is assigned a value that is never used: "arg"
+warning_240.pwn(160) : warning 204: symbol is assigned a value that is never used: "local_var"
 """
 }

--- a/source/compiler/tests/warning_240.pwn
+++ b/source/compiler/tests/warning_240.pwn
@@ -153,7 +153,7 @@ test_locals()
 
 test_globals()
 {
-	// Assignments to global variables are not tracked (yet?)
+	// Assignments to global variables are not tracked
 	global_var = 1;
 	global_var = 2;
 	UseVariable(global_var);

--- a/source/compiler/tests/warning_240.pwn
+++ b/source/compiler/tests/warning_240.pwn
@@ -40,6 +40,34 @@ test_locals()
 	}
 
 	{
+		new local_var;
+		if (TRUE)
+		{
+			local_var = 1;
+		}
+		else
+		{
+		}
+		// The previous assignment ("local_var = 1") should be reported as unused.
+		local_var = 2; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var;
+		if (TRUE)
+		{
+		}
+		else
+		{
+			local_var = 1;
+		}
+		// The previous assignment ("local_var = 1") should be reported as unused.
+		local_var = 2; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
 		new local_var = 1;
 		if (TRUE) {}
 		// The previous assignment ("local_var = 1") should be reported as unused.
@@ -51,6 +79,30 @@ test_locals()
 		new local_var = 1;
 		switch (TRUE)
 		{
+			default: local_var = 2;
+		}
+		// The previous assignment ("local_var = 2") should be reported as unused.
+		local_var = 3; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		switch (TRUE)
+		{
+			case true: local_var = 2;
+			default: {}
+		}
+		// The previous assignment ("local_var = 2") should be reported as unused.
+		local_var = 3; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		switch (TRUE)
+		{
+			case true: {}
 			default: local_var = 2;
 		}
 		// The previous assignment ("local_var = 2") should be reported as unused.

--- a/source/compiler/tests/warning_240.pwn
+++ b/source/compiler/tests/warning_240.pwn
@@ -1,116 +1,173 @@
-#include <core>
-#include <console>
+stock UseVariable(var) return var;
+
+stock const bool:TRUE = true, bool:FALSE = false;
 
 new global_var;
 static global_static_var;
 
-test_local()
+test_locals()
 {
-	new local_var;
-	local_var = 1;
-	local_var = 2; // warning 240
-	local_var = 3; // warning 240
-	#pragma unused local_var
-	local_var = 4; // warning 204
-	new local_var2 = 0;
-	local_var2 = 1;
-	#pragma unused local_var2
+	{
+		new local_var = 1;
+		local_var = 2; // warning 240
+		UseVariable(local_var);
+		local_var = 3; // warning 204
+	}
+
+	{
+		// Zero-initialization at definition is a special case, as it doesn't
+		// generate any extra code, because variables are already zero-initialized
+		// by default. Also, when storing a value into the variable, people often
+		// forget that they zero-initialized the said variable at its definition
+		// and didn't use that value, so usually warning 240 doesn't mean anything
+		// suspicious in such cases, and thus can be just annoying to the user.
+		// This is why if the variable was zero-initialized at definition,
+		// warning 240 is not printed for the subsequent assignment.
+		new local_var = 0;
+		local_var = 1;
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		if (TRUE)
+		{
+			local_var = 2;
+		}
+		// The previous assignment ("local_var = 2") should be reported as unused.
+		local_var = 3; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		if (TRUE) {}
+		// The previous assignment ("local_var = 1") should be reported as unused.
+		local_var = 2; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		switch (TRUE)
+		{
+			default: local_var = 2;
+		}
+		// The previous assignment ("local_var = 2") should be reported as unused.
+		local_var = 3; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		switch (TRUE)
+		{
+			default: {}
+		}
+		// The previous assignment ("local_var = 1") should be reported as unused.
+		local_var = 2; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var;
+		do {
+			local_var = 0;
+		} while (FALSE);
+		// The previous assignment ("local_var = 0") should NOT be reported as unused,
+		// as the compiler can't analyze the control flow of the loop.
+		local_var = 1;
+		UseVariable(local_var);
+	}
+
+	{
+		new local_var = 1;
+		do {} while (FALSE);
+		// The previous assignment ("local_var = 1") should be reported as unused.
+		local_var = 1; // warning 240
+		UseVariable(local_var);
+	}
+
+	{
+		// "warning 204" is not applicable to "static" local variables, as the
+		// assigned value can be used on the next function call, which is why
+		// assignment "local_static_var = 4" should NOT be reported as unused.
+		static local_static_var = 1;
+		local_static_var = 1; // warning 240
+		UseVariable(local_static_var);
+		local_static_var = 4;
+	}
 }
 
-test_local2()
+test_globals()
 {
-	new local_var, local_var2 = 1;
-	if (random(2))
-	{
-		local_var = 1; // warning 204
-	}
-	local_var2 = 2; // warning 240
-	switch (random(2))
-	{
-		case 0:
-		{
-			local_var2 = 1; // warning 204
-		}
-	}
+	// Assignments to global variables are not tracked (yet?)
+	global_var = 1;
+	global_var = 2;
+	UseVariable(global_var);
+	global_var = 3;
+
+	global_static_var = 1;
+	global_static_var = 2;
+	UseVariable(global_static_var);
+	global_static_var = 3;
+}
+
+test_args(arg, &refarg)
+{
+	// Technically function arguments are like local variables, except that they
+	// have a value implicitly assigned to them at the start of the function body.
+	// This is why on the subsequent assignment ("arg = 1") the compiler should warn
+	// about the previously assigned value being unused.
+	arg = 1; // warning 240
+	if (TRUE)
+		arg = 2;
+	do {} while (FALSE);
+	arg = 3; // warning 240, warning 204
+
+	// "warning 203" is not applicable to references, as the value might be used
+	// outside of the function.
+	refarg = 1;
+	refarg = 2; // warning 240
+	UseVariable(refarg);
+	refarg = 3;
 }
 
 test_goto()
 {
 	{
-		new local_var;
-		#pragma unused local_var
+		new local_var = 0;
+		UseVariable(local_var);
 lbl_1:
-		if (random(2))
+		if (TRUE)
 		{
-			local_var = 1; // no warning(s)
+			// Because of "goto", the compiler can't be certain if assignment
+			// "local_var = 1" is used or not. Since the jump is being made to
+			// a previously defined label, the compiler assumes the assignment
+			// is used, to avoid false-positives.
+			local_var = 1;
 			goto lbl_1;
 		}
 	}
 	{
-		new local_var2;
-		#pragma unused local_var2
-		if (random(2))
+		new local_var = 0;
+		UseVariable(local_var);
+		if (TRUE)
 		{
-			local_var2 = 1; // warning 204
+			// Since the jump is being made to a yet undefined label, and the assignment
+			// is not used at any later point, this means the compiler may continue working
+			// in its usual (linear) way to see if assignment "local_var2 = 1" is used or not.
+			local_var = 1; // warning 204
 			goto lbl_2;
 		}
 lbl_2:
 	}
 }
 
-test_local_static()
-{
-	static local_static_var = 0;
-	local_static_var = 1; // warning 240
-	local_static_var = 2; // warning 240
-	#pragma unused local_static_var
-	local_static_var = 4;
-}
-
-test_global()
-{
-	global_var = 1;
-	global_var = 2;
-	global_var = 3;
-	#pragma unused global_var
-	global_var = 4;
-}
-
-test_global_static()
-{
-	global_static_var = 1;
-	global_static_var = 2;
-	global_static_var = 3;
-	#pragma unused global_static_var
-	global_static_var = 4;
-}
-
-test_arg1(arg)
-{
-	if (random(2))
-		arg = 1;
-	arg = 0; // warning 240
-	arg = 1; // warning 240, warning 204
-}
-
-test_arg2(arg)
-{
-	if (arg)
-		arg = 1; // warning 204
-}
-
-test_arg3(arg)
-{
-	switch (arg)
-	{
-		case 0: arg = 1; // warning 204
-	}
-}
-
 stock Tag:operator =(oper)
 	return Tag:oper;
 
-test_ovl_assignment()
+test_overloaded()
 {
 	// Overloaded assignments are essentially function calls which may have
 	// desirable side effects, so they shouldn't trigger warning 204.
@@ -121,14 +178,10 @@ test_ovl_assignment()
 
 main()
 {
-	test_local();
-	test_local2();
+	test_locals();
+	test_globals();
+	new x;
+	test_args(0,x);
 	test_goto();
-	test_local_static();
-	test_global();
-	test_global_static();
-	test_arg1(1);
-	test_arg2(1);
-	test_arg3(1);
-	test_ovl_assignment();
+	test_overloaded();
 }

--- a/source/compiler/tests/warning_240.pwn
+++ b/source/compiler/tests/warning_240.pwn
@@ -19,11 +19,12 @@ test_local()
 
 test_local2()
 {
-	new local_var, local_var2;
+	new local_var, local_var2 = 1;
 	if (random(2))
 	{
 		local_var = 1; // warning 204
 	}
+	local_var2 = 2; // warning 240
 	switch (random(2))
 	{
 		case 0:
@@ -86,6 +87,8 @@ test_global_static()
 
 test_arg1(arg)
 {
+	if (random(2))
+		arg = 1;
 	arg = 0; // warning 240
 	arg = 1; // warning 240, warning 204
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR continues the work regarding detection of unused assignments (warnings 204 and 240), the first part of which was done in #480.
* Fixes a bug with assignments inside loops being mistakenly reported as unused after using `break` or `continue`.
```Pawn
new var = 0;
for (/* ... */) {
    if (/* ... */) {
        var = 0;
        break;
    }

    // Before the fix, the compiler falsely reported the previous assignment "var = 0"
    // as unused ("warning 240: previously assigned value is never used (symbol "var")").
    var = var + 1;
}
```

* Improves the unused assignment detection algorithm by tracking the "compound statement" nesting level for each assignment, which allows to detect more complicated cases of unused assignments.

**Which issue(s) this PR fixes**:

Fixes #479

**What kind of pull this is**:

* [x] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

This PR relies on the fix from #532, so you'll probably want to review and merge that PR first.