### PR TITLE
error 094: division by zero

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -644,7 +644,7 @@ static cell flooreddiv(cell a,cell b,int return_remainder)
   cell q,r;
 
   if (b==0) {
-    error(29);
+    error(94);  /* division by zero */
     return 0;
   } /* if */
   /* first implement truncated division in a portable way */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -620,6 +620,10 @@ static void plnge2(void (*oper)(void),
     } /* if */
     /* ??? ^^^ should do same kind of error checking with functions */
 
+    /* If we're handling a division operation, make sure the divisor is not zero. */
+    if ((oper==os_div || oper==os_mod) && lval2->ident==iCONSTEXPR && lval2->constval==0)
+      error(94); /* division by zero */
+
     /* check whether an "operator" function is defined for the tag names
      * (a constant expression cannot be optimized in that case)
      */
@@ -643,10 +647,8 @@ static cell flooreddiv(cell a,cell b,int return_remainder)
 {
   cell q,r;
 
-  if (b==0) {
-    error(94);  /* division by zero */
+  if (b==0)
     return 0;
-  } /* if */
   /* first implement truncated division in a portable way */
   #define IABS(a)       ((a)>=0 ? (a) : (-a))
   q=IABS(a)/IABS(b);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -132,7 +132,8 @@ static char *errmsg[] = {
 /*090*/  "public functions may not return arrays (symbol \"%s\")\n",
 /*091*/  "ambiguous constant; tag override is required (symbol \"%s\")\n",
 /*092*/  "functions may not return arrays of unknown size (symbol \"%s\")\n",
-/*093*/  "\"__addressof\" operator is invalid in preprocessor expressions\n"
+/*093*/  "\"__addressof\" operator is invalid in preprocessor expressions\n",
+/*094*/  "division by zero\n"
 };
 
 static char *fatalmsg[] = {

--- a/source/compiler/tests/error_094.meta
+++ b/source/compiler/tests/error_094.meta
@@ -1,0 +1,9 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+error_094.pwn(6) : error 094: division by zero
+error_094.pwn(7) : error 094: division by zero
+error_094.pwn(13) : error 094: division by zero
+error_094.pwn(14) : error 094: division by zero
+"""
+}

--- a/source/compiler/tests/error_094.pwn
+++ b/source/compiler/tests/error_094.pwn
@@ -1,0 +1,20 @@
+#include <console>
+
+main()
+{
+	// Case 1: Both operands are compile-time constants
+	printf("%d", 1 / 0); // error 094
+	printf("%d", 1 % 0); // error 094
+	printf("%d", 1 / 1);
+	printf("%d", 1 % 1);
+
+	// Case 2: Only the divisor is a constant
+	new var = 0;
+	printf("%d", var / 0); // error 094
+	printf("%d", var % 0); // error 094
+	printf("%d", var / 1);
+	printf("%d", var % 1);
+
+	printf("%d", 1 / var); // Just to make sure the error works only
+	printf("%d", 1 % var); // if the divisor is a constant value
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

This PR does the following:
* Adds a distinct error (094) for zero division, instead of reusing error 029 (`invalid expression, assumed zero`), as first suggested in #528.
* Makes error 094 also work if the left operand (dividend) is not constant.
  Previously the check for zero division was located in function `flooreddiv()` (file `sc3.c`) that calculated the result of division when both operands are compile-time constants, which means that the check only worked when the dividend was constant.

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

Fixes #

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
