### PR TITLE
[MERGED] Restrict local constants to the local block they're defined in

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5268,6 +5268,8 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag)
 redef_enumfield:
   sym=addsym(name,val,iCONSTEXPR,vclass,tag,uDEFINE);
   assert(sym!=NULL);            /* fatal error 103 must be given on error */
+  if (vclass==sLOCAL)
+    sym->compound=nestlevel;
   return sym;
 }
 

--- a/source/compiler/tests/gh_541.meta
+++ b/source/compiler/tests/gh_541.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_541.pwn(21) : error 017: undefined symbol "CONSTVAL"
+gh_541.pwn(22) : error 017: undefined symbol "ENUM_ITEM1"
+  """
+}

--- a/source/compiler/tests/gh_541.pwn
+++ b/source/compiler/tests/gh_541.pwn
@@ -1,0 +1,23 @@
+main()
+{
+	new const bool:TRUE = true;
+	if (TRUE)
+	{
+		const CONSTVAL = 0;
+		enum
+		{
+			ENUM_ITEM1
+		};
+		if (TRUE)
+		{
+			return CONSTVAL;
+		}
+		if (TRUE)
+		{
+			return ENUM_ITEM1;
+		}
+	}
+	if (TRUE)
+		return CONSTVAL; // error 017: undefined symbol "CONSTVAL"
+	return ENUM_ITEM1; // error 017: undefined symbol "ENUM_ITEM1"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Restricts local constants to the scope of the compound block they were defined in, instead of the scope of the whole function, in order to fix the bug described in #541.

**Which issue(s) this PR fixes**:

Fixes #541

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
