### PR TITLE
[MERGED] Make `#assert` work without debug mode

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1116,7 +1116,7 @@ static int command(void)
     check_empty(lptr);
     break;
   case tpASSERT:
-    if (!SKIPPING && (sc_debug & sCHKBOUNDS)!=0) {
+    if (!SKIPPING) {
       for (str=(char*)lptr; *str<=' ' && *str!='\0'; str++)
         /* nothing */;          /* save start of expression */
       preproc_expr(&val,NULL);  /* get constant expression (or 0 on error) */

--- a/source/compiler/tests/gh_542.meta
+++ b/source/compiler/tests/gh_542.meta
@@ -1,0 +1,9 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_542.pwn(2) : fatal error 110: assertion failed: false
+
+
+Compilation aborted.
+  """
+}

--- a/source/compiler/tests/gh_542.pwn
+++ b/source/compiler/tests/gh_542.pwn
@@ -1,0 +1,3 @@
+#pragma option -d0
+#assert false
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the check that previously made `#assert` work only in debug mode (see #542 for details).

**Which issue(s) this PR fixes**:

Fixes #542

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: