### PR TITLE
[MERGED] Fix enum increments `*= 1` and `<<= 0` working as `+= 1`

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2928,7 +2928,8 @@ static void decl_enum(int vclass,int fstatic)
   cell val,value,size;
   char *str;
   int tag,explicittag;
-  cell increment,multiplier;
+  int inctok;
+  cell increment;
   constvalue_root *enumroot=NULL;
   symbol *enumsym=NULL;
   short filenum;
@@ -2958,18 +2959,18 @@ static void decl_enum(int vclass,int fstatic)
     enumname[0]='\0';
   } /* if */
 
-  /* get increment and multiplier */
+  /* get the increment */
   increment=1;
-  multiplier=1;
+  inctok=taADD;
   if (matchtoken('(')) {
-    if (matchtoken(taADD)) {
+    int tok=lex(&val,&str);
+    if (tok==taADD || tok==taMULT || tok==taSHL) {
+      inctok=tok;
       constexpr(&increment,NULL,NULL);
-    } else if (matchtoken(taMULT)) {
-      constexpr(&multiplier,NULL,NULL);
-    } else if (matchtoken(taSHL)) {
-      constexpr(&val,NULL,NULL);
-      while (val-->0)
-        multiplier*=2;
+      if (tok==taSHL && increment<0)
+        increment=0;
+    } else {
+      lexpush();
     } /* if */
     needtoken(')');
   } /* if */
@@ -3005,7 +3006,7 @@ static void decl_enum(int vclass,int fstatic)
     } else {
       constname[0]='\0';
     } /* if */
-    size=increment;                     /* default increment of 'val' */
+    size=(inctok==taADD) ? increment : 1;/* default increment of 'val' */
     fieldtag=0;                         /* default field tag */
     if (matchtoken('[')) {
       constexpr(&size,&fieldtag,NULL);  /* get size */
@@ -3027,6 +3028,8 @@ static void decl_enum(int vclass,int fstatic)
     sym->parent=enumsym;
     if (enumsym)
       enumsym->child=sym;
+    if (vclass==sLOCAL)
+      sym->compound=nestlevel;
 
     if (fstatic)
       sym->fnumber=filenum;
@@ -3036,10 +3039,12 @@ static void decl_enum(int vclass,int fstatic)
       sym->usage |= uENUMFIELD;
       append_constval(enumroot,constname,value,tag);
     } /* if */
-    if (multiplier==1)
+    if (inctok==taADD)
       value+=size;
-    else
-      value*=size*multiplier;
+    else if (inctok==taMULT)
+      value*=(size*increment);
+    else // taSHL
+      value*=(size << increment);
   } while (matchtoken(','));
   needtoken('}');       /* terminates the constant list */
   matchtoken(';');      /* eat an optional ; */

--- a/source/compiler/tests/enum_increment.meta
+++ b/source/compiler/tests/enum_increment.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+  """
+}

--- a/source/compiler/tests/enum_increment.pwn
+++ b/source/compiler/tests/enum_increment.pwn
@@ -1,0 +1,86 @@
+#pragma option -d1 // TODO: Remove this line when #544 is merged
+
+main()
+{
+	enum e1
+	{
+		e1Elem1[3],
+		e1Elem2,
+		e1Elem3
+	};
+	new arr1[e1];
+	#pragma unused arr1
+	#assert sizeof arr1[e1Elem1] == 3
+	#assert sizeof arr1[e1Elem2] == 1
+	#assert sizeof arr1[e1Elem3] == 1
+	#assert _:e1Elem1 == 0
+	#assert _:e1Elem2 == 3
+	#assert _:e1Elem3 == 4
+
+	enum e2 (+= 2)
+	{
+		e2Elem1[3],
+		e2Elem2,
+		e2Elem3
+	};
+	new arr2[e2];
+	#pragma unused arr2
+	#assert sizeof arr2[e2Elem1] == 3
+	#assert sizeof arr2[e2Elem2] == 2
+	#assert sizeof arr2[e2Elem3] == 2
+	#assert _:e2Elem1 == 0
+	#assert _:e2Elem2 == 3
+	#assert _:e2Elem3 == 5
+
+	enum e3 (*= 2)
+	{
+		e3Elem1 = 1,
+		e3Elem2[3],
+		e3Elem3
+	};
+	new arr3[e3];
+	#pragma unused arr3
+	#assert sizeof arr3[e3Elem1] == 1
+	#assert sizeof arr3[e3Elem2] == 3
+	#assert sizeof arr3[e3Elem3] == 1
+	#assert _:e3Elem1 == 1
+	#assert _:e3Elem2 == 2  // 1 * (1 * 2); the first "1" is the value of the previous
+	                        // enum item, the second "1" is the size of the previous
+	                        // item, and "2" is the increment (multiplier)
+	#assert _:e3Elem3 == 12 // 2 * (3 * 2)
+
+	enum e4 (<<= 2)
+	{
+		e4Elem1 = 1,
+		e4Elem2[3],
+		e4Elem3
+	};
+	new arr4[e4];
+	#pragma unused arr4
+	#assert sizeof arr4[e4Elem1] == 1
+	#assert sizeof arr4[e4Elem2] == 3
+	#assert sizeof arr4[e4Elem3] == 1
+	#assert _:e4Elem1 == 1
+	#assert _:e4Elem2 == 4  // 1 * (1 << 2) = 4
+	#assert _:e4Elem3 == 48 // 4 * (3 << 2) = 48
+
+	enum (<<= 0)
+	{
+		e5Elem1,
+		e5Elem2,
+		e5Elem3
+	};
+	#assert _:e5Elem1 == 0
+	#assert _:e5Elem2 == 0
+	#assert _:e5Elem3 == 0
+
+	enum (*= 1)
+	{
+		e5Elem1,
+		e5Elem2,
+		e5Elem3
+	};
+	#assert _:e5Elem1 == 0
+	#assert _:e5Elem2 == 0
+	#assert _:e5Elem3 == 0
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Rewrites the code for enum increment processing, in order to fix increments `(*= 1)` and `(<<= 0)` working as `(+= 1)` (see #540) and make it more extendable in general (for example, this should open up a way for validation of the shift count for enum items if the increment was specified as a left shift; I'm going to update #539 to incorporate this fix).

**Which issue(s) this PR fixes**:

Fixes #540

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: