### PR TITLE
[MERGED] warning 24X: redundant code: switch control expression is constant

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5891,6 +5891,7 @@ static void doswitch(void)
   int swdefault,casecount;
   int tok,endtok;
   int swtag,csetag;
+  int ident;
   cell val;
   char *str;
   constvalue_root caselist = { NULL, NULL};   /* case list starts empty */
@@ -5898,7 +5899,9 @@ static void doswitch(void)
   char labelname[sNAMEMAX+1];
 
   endtok= matchtoken('(') ? ')' : tDO;
-  doexpr(TRUE,FALSE,FALSE,FALSE,&swtag,NULL,TRUE,NULL);/* evaluate switch expression */
+  ident=doexpr(TRUE,FALSE,FALSE,FALSE,&swtag,NULL,TRUE,NULL);   /* evaluate switch expression */
+  if (ident==iCONSTEXPR)
+    error(241);                 /* redundant code: switch control expression is constant */
   needtoken(endtok);
   /* generate the code for the switch statement, the label is the address
    * of the case table (to be generated later).

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -197,7 +197,8 @@ static char *warnmsg[] = {
 /*237*/  "user warning: %s\n",
 /*238*/  "meaningless combination of class specifiers (%s)\n",
 /*239*/  "literal array/string passed to a non-const parameter\n",
-/*240*/  "previously assigned value is never used (symbol \"%s\")\n"
+/*240*/  "previously assigned value is never used (symbol \"%s\")\n",
+/*241*/  "redundant code: switch control expression is constant\n"
 };
 
 static char *noticemsg[] = {

--- a/source/compiler/tests/warning_241.meta
+++ b/source/compiler/tests/warning_241.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+warning_241.pwn(6) : warning 241: redundant code: switch control expression is constant
+warning_241.pwn(7) : warning 241: redundant code: switch control expression is constant
+warning_241.pwn(8) : warning 241: redundant code: switch control expression is constant
+"""
+}

--- a/source/compiler/tests/warning_241.pwn
+++ b/source/compiler/tests/warning_241.pwn
@@ -1,0 +1,10 @@
+main()
+{
+	const CONST_1 = 1;
+	new var = 0;
+
+	switch (0) {} // warning 241
+	switch (CONST_1) {} // warning 241
+	switch (CONST_1 + 1) {} // warning 241
+	switch (var) {}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows the compiler to warn the user about redundant code if a `switch` control expression has a constant result, as suggested in #528.
```Pawn
switch (1) // warning 24X: redundant code: switch control expression is constant
{
    // ...
}
```
There are already similar warnings for `if`, `while`, `do-while` and `for` statements ("`205: redundant code: constant expression is zero`" and "`206: redundant test: constant expression is non-zero`"), so I think it should make sense to adopt a similar warning for `switch`.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: