### PR TITLE
[MERGED] Minor fixes for `sizeof`/`tagof` used as a default value

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4281,6 +4281,10 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
           } /* if */
           if (ident==iVARIABLE) /* make sure we set this only if not a reference */
             arg->hasdefault |= size_tag_token;  /* uSIZEOF or uTAGOF */
+        } else {
+          /* ignore the argument, otherwise it would cause more error messages, until it
+           * will trigger a fatal error because of too many error messages on one line */
+          lexclr(FALSE);
         } /* if */
         while (paranthese--)
           needtoken(')');

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4261,7 +4261,7 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
         paranthese=0;
         while (matchtoken('('))
           paranthese++;
-        if (matchtoken(tLABEL)) {
+        if (size_tag_token==uTAGOF && matchtoken(tLABEL)) {
           constvalue *tagsym;
           tokeninfo(&val,&symname);
           tagsym=find_constval(&tagname_tab,symname,0);

--- a/source/compiler/tests/tagof_tag_argdefault.meta
+++ b/source/compiler/tests/tagof_tag_argdefault.meta
@@ -1,5 +1,6 @@
 {
   'test_type': 'output_check',
   'errors': """
+tagof_tag_argdefault.pwn(18) : error 001: expected token: "-identifier-", but found "-label-"
 """
 }

--- a/source/compiler/tests/tagof_tag_argdefault.pwn
+++ b/source/compiler/tests/tagof_tag_argdefault.pwn
@@ -15,10 +15,13 @@ Func1(a = tagof(Float:))
 Func2(a = tagof(Tag:))
 	return a;
 
+Func3(Tag:a, tag = sizeof(Tag:)) // error 001: expected token: "-identifier-", but found "-label-"
+	return (a + Tag:0, tag);
+
 main()
 {
 	new Tag:t = Tag:0;
-	#pragma unused t
 	Func1();
 	Func2();
+	Func3(t);
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does the following:
* Fixes a bug with `sizeof` being possible to use on tags when used as a default value for function arguments:
```Pawn
Func(Tag:arg1, arg2 = sizeof(Tag:)) // normally "sizeof(Tag:)" should not compile
{
    #pragma unused arg1, arg2
}

main() Func(Tag:0);
```
The bug was introcuded in PR #488, which implemented `tagof(<tag>)` for default values; this PR adds a check that was missing in the original implementation.

* Makes the compiler ignore the argument of `sizeof`/`tagof` if it's not a valid symbol.
Example:
```
Func(size = sizeof(Tag:))
    return size;

main()
    return Func(0);
```
Before:
```
test.pwn(1) : error 001: expected token: "-identifier-", but found "-label-"
test.pwn(1) : warning 221: label name "Tag" shadows tag name
test.pwn(1) : warning 203: symbol is never used: "Tag"
test.pwn(1) : warning 203: symbol is never used: "size"
test.pwn(1) : error 010: invalid function or declaration
test.pwn(1 -- 2) : error 010: invalid function or declaration
test.pwn(1 -- 2) : fatal error 107: too many error messages on one line
```
After:
```
test.pwn(1) : error 001: expected token: "-identifier-", but found "-label-"
```
After this change, by ignoring the invalid argument of `sizeof`/`tagof` the compiler will be able to print only one error message and continue analyzing the code in a normal way, instead of printing multiple cryptic error messages and aborting with a fatal error.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
