### PR TITLE
[MERGED] Fix `const` being applied only to the highest array dimension

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2242,8 +2242,12 @@ static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,int fst
     sc_curstates=0;
     if (ispublic)
       sym->usage|=uPUBLIC;
-    if (fconst)
-      sym->usage|=uCONST;
+    if (fconst) {
+      symbol *cur=sym;
+      do {
+        cur->usage|=uCONST;
+      } while ((cur=cur->child)!=NULL);
+    } /* if */
     if (fstock)
       sym->usage|=uSTOCK;
     if (fstatic)
@@ -2371,8 +2375,12 @@ static int declloc(int fstatic)
     /* now that we have reserved memory for the variable, we can proceed
      * to initialize it */
     assert(sym!=NULL);          /* we declared it, it must be there */
-    if (fconst)
-      sym->usage|=uCONST;
+    if (fconst) {
+      symbol *cur=sym;
+      do {
+        cur->usage|=uCONST;
+      } while ((cur=cur->child)!=NULL);
+    } /* if */
     if (!fstatic) {             /* static variables already initialized */
       if (ident==iVARIABLE) {
         /* simple variable, also supports initialization */

--- a/source/compiler/tests/gh_553.meta
+++ b/source/compiler/tests/gh_553.meta
@@ -1,0 +1,13 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_553.pwn(13) : error 022: must be lvalue (non-constant)
+gh_553.pwn(13) : warning 215: expression has no effect
+gh_553.pwn(14) : error 022: must be lvalue (non-constant)
+gh_553.pwn(14) : warning 215: expression has no effect
+gh_553.pwn(18) : error 022: must be lvalue (non-constant)
+gh_553.pwn(18) : warning 215: expression has no effect
+gh_553.pwn(19) : error 022: must be lvalue (non-constant)
+gh_553.pwn(19) : warning 215: expression has no effect
+  """
+}

--- a/source/compiler/tests/gh_553.pwn
+++ b/source/compiler/tests/gh_553.pwn
@@ -1,0 +1,22 @@
+new const global_const_array_2d[1][1];
+new const global_const_array_1d[1];
+new global_array_2d[1][1];
+new global_array_1d[1];
+
+main()
+{
+	new const local_const_array_2d[1][1];
+	new const local_const_array_1d[1];
+	new local_array_2d[1][1];
+	new local_array_1d[1];
+
+	global_const_array_2d[0][0] = 0;
+	global_const_array_1d[0] = 0;
+	global_array_2d[0][0] = 0;
+	global_array_1d[0] = 0;
+
+	local_const_array_2d[0][0] = 0;
+	local_const_array_1d[0] = 0;
+	local_array_2d[0][0] = 0;
+	local_array_1d[0] = 0;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `uCONST` flag being applied only to the symbol that represents the highest array dimension and not to the nested dimension symbols (see #553).

**Which issue(s) this PR fixes**:

Fixes #553

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

