### PR TITLE
[MERGED] Fix crash related to state functions

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3911,9 +3911,8 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
     litidx=0;
   } /* if */
   for (i=0; i<argcnt; i++) {
-    if (sym->dim.arglist[i].ident==iREFARRAY) {
-      lvar=findloc(sym->dim.arglist[i].name);
-      assert(lvar!=NULL);
+    if (sym->dim.arglist[i].ident==iREFARRAY
+        && (lvar=findloc(sym->dim.arglist[i].name))!=NULL) {
       if ((sym->dim.arglist[i].usage & uWRITTEN)==0) {
         /* check if the argument was written in this definition */
         depend=lvar;
@@ -3927,9 +3926,9 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
       } /* if */
       /* mark argument as written if it was written in another definition */
       lvar->usage|=sym->dim.arglist[i].usage & uWRITTEN;
-    } /* if */    
+    } /* if */
   } /* for */
-  
+
   testsymbols(&loctab,0,TRUE,TRUE);     /* test for unused arguments and labels */
   delete_symbols(&loctab,0,TRUE,TRUE);  /* clear local variables queue */
   assert(loctab.next==NULL);

--- a/source/compiler/tests/gh_557.meta
+++ b/source/compiler/tests/gh_557.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_557.pwn(2) : error 025: function heading differs from prototype
+  """
+}

--- a/source/compiler/tests/gh_557.pwn
+++ b/source/compiler/tests/gh_557.pwn
@@ -1,0 +1,3 @@
+stock f(a[]) <b:A> {}
+stock f(b[]) <b:B> {}
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a NULL pointer dereference when a state function is implemented with parameter(s) named differently from the previous implementation (see #557) or when a function is implemented or redeclared with parameter(s) named differently from the first declaration.

**Which issue(s) this PR fixes**:

Fixes #557

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: