### PR TITLE
[MERGED] Fix the array return bug

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -955,6 +955,8 @@ SC_VDECL int pc_memflags;     /* special flags for the stack/heap usage */
 SC_VDECL int pc_naked;        /* if true mark following function as naked */
 SC_VDECL int pc_compat;       /* running in compatibility mode? */
 SC_VDECL int pc_recursion;    /* enable detailed recursion report? */
+SC_VDECL int pc_retexpr;      /* true if the current expression is a part of a "return" statement */
+SC_VDECL int pc_retheap;      /* heap space (in bytes) to be manually freed when returning an array returned by another function */
 
 SC_VDECL constvalue_root sc_automaton_tab; /* automaton table */
 SC_VDECL constvalue_root sc_state_tab;     /* state table */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5557,8 +5557,16 @@ static int doexpr(int comma,int chkeffect,int allowarray,int mark_endexpr,
   errorset(sEXPRMARK,0);
   do {
     /* on second round through, mark the end of the previous expression */
-    if (index!=stgidx)
+    if (index!=stgidx) {
       markexpr(sEXPR,NULL,0);
+      /* also, if this is not the first expression and we are inside a "return"
+       * statement, we need to manually free the heap space allocated for the
+       * array returned by the function called in the previous expression */
+      if (pc_retexpr) {
+        modheap(pc_retheap);
+        pc_retheap=0;
+      } /* if */
+    } /* if */
     pc_sideeffect=FALSE;
     pc_ovlassignment=FALSE;
     ident=expression(val,tag,symptr,chkfuncresult);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -906,6 +906,7 @@ static void resetglobals(void)
   sc_curstates=0;
   pc_memflags=0;
   pc_naked=FALSE;
+  pc_retexpr=FALSE;
   emit_flags=0;
   emit_stgbuf_idx=-1;
 }
@@ -7631,7 +7632,11 @@ static void doreturn(void)
     /* "return <value>" */
     if ((rettype & uRETNONE)!=0)
       error(78);                        /* mix "return;" and "return value;" */
+    assert(pc_retexpr==FALSE);
+    pc_retexpr=TRUE;
+    pc_retheap=0;
     ident=doexpr(TRUE,FALSE,TRUE,FALSE,&tag,&sym,TRUE,NULL);
+    pc_retexpr=FALSE;
     needtoken(tTERM);
     /* see if this function already has a sub type (an array attached) */
     assert(curfunc!=NULL);
@@ -7738,6 +7743,7 @@ static void doreturn(void)
         /* moveto1(); is not necessary, callfunction() does a popreg() */
       } /* if */
     } /* if */
+    modheap(pc_retheap);
     /* try to use "operator=" if tags don't match */
     if (!matchtag(curfunc->tag,tag,TRUE))
       check_userop(NULL,tag,curfunc->tag,2,NULL,&tag);

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -711,7 +711,14 @@ SC_FUNC int expression(cell *val,int *tag,symbol **symptr,int chkfuncresult)
     rvalue(&lval);
   /* scrap any arrays left on the heap */
   assert(decl_heap>=locheap);
-  modheap((locheap-decl_heap)*sizeof(cell));  /* remove heap space, so negative delta */
+  if (!pc_retexpr) {
+    modheap((locheap-decl_heap)*sizeof(cell));/* remove heap space, so negative delta */
+  } else {
+    /* we need to copy the data from the leftover space first (e.g. when used
+     * from 'return' when returning a string returned by another function),
+     * so we'll free it manually later */
+    pc_retheap=(locheap-decl_heap)*sizeof(cell);
+  } /* if */
   decl_heap=locheap;
 
   if (lval.ident==iCONSTEXPR && val!=NULL)    /* constant expression */

--- a/source/compiler/scvars.c
+++ b/source/compiler/scvars.c
@@ -97,6 +97,8 @@ SC_VDEFINE int pc_memflags=0;               /* special flags for the stack/heap 
 SC_VDEFINE int pc_naked=FALSE;              /* if true mark following function as naked */
 SC_VDEFINE int pc_compat=FALSE;             /* running in compatibility mode? */
 SC_VDEFINE int pc_recursion=FALSE;          /* enable detailed recursion report? */
+SC_VDEFINE int pc_retexpr=FALSE;            /* true if the current expression is a part of a "return" statement */
+SC_VDEFINE int pc_retheap=0;                /* heap space (in bytes) to be manually freed when returning an array returned by another function */
 
 SC_VDEFINE constvalue_root sc_automaton_tab = { NULL, NULL}; /* automaton table */
 SC_VDEFINE constvalue_root sc_state_tab = { NULL, NULL};   /* state table */

--- a/source/compiler/tests/gh_567.meta
+++ b/source/compiler/tests/gh_567.meta
@@ -1,0 +1,15 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  nop
+[0-9a-f]+  heap 00000030
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  load.s.alt 0000000c
+[0-9a-f]+  movs 00000030
+[0-9a-f]+  heap ffffffd0
+[0-9a-f]+  retn
+"""
+}

--- a/source/compiler/tests/gh_567.meta
+++ b/source/compiler/tests/gh_567.meta
@@ -2,6 +2,23 @@
   'test_type': 'pcode_check',
   'code_pattern': r"""
 [0-9a-f]+  nop
+[0-9a-f]+  load.pri [0-9a-f]+
+[0-9a-f]+  jzer [0-9a-f]+
+[0-9a-f]+  heap 00000030
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  load.s.alt 0000000c
+[0-9a-f]+  movs 00000030
+[0-9a-f]+  heap ffffffd0
+[0-9a-f]+  retn
+[0-9a-f]+  heap 00000030
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  pop.pri
+[0-9a-f]+  heap ffffffd0
 [0-9a-f]+  heap 00000030
 [0-9a-f]+  push.alt
 [0-9a-f]+  push.c 00000000

--- a/source/compiler/tests/gh_567.pwn
+++ b/source/compiler/tests/gh_567.pwn
@@ -1,0 +1,19 @@
+#pragma option -O0
+#include <console>
+
+StringOrigin()
+{
+	static const string[] = "Hello world";
+	return string;
+}
+
+ReturnString()
+{
+	__emit nop; // mark the start of checked P-code
+	return StringOrigin();
+}
+
+main()
+{
+	print(ReturnString());
+}

--- a/source/compiler/tests/gh_567.pwn
+++ b/source/compiler/tests/gh_567.pwn
@@ -9,8 +9,11 @@ StringOrigin()
 
 ReturnString()
 {
+	static x = 0;
 	__emit nop; // mark the start of checked P-code
-	return StringOrigin();
+	if (x)
+		return StringOrigin();
+	return StringOrigin(), StringOrigin();
 }
 
 main()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes bad code generation when returning an array returned by another function (see #293).

**Which issue(s) this PR fixes**:

Fixes #293

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

The test code is based on the [array return bug demonstration](https://github.com/sampctl/pawn-array-return-bug) by @Southclaws.