### PR TITLE
Fixes for redefinition of enum root symbols

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3017,6 +3017,10 @@ static void decl_enum(int vclass,int fstatic)
       unique=0;
       if (fstatic)
         enumsym->fnumber=filenum;
+      /* if we redefined a root symbol of another enum, then we need to delete
+       * the previous list of enum elements, otherwise it would be leaked */
+      if (enumsym->dim.enumlist!=NULL)
+        delete_consttable(enumsym->dim.enumlist);
     } /* if */
     /* start a new list for the element names */
     if ((enumroot=(constvalue_root*)malloc(sizeof(constvalue_root)))==NULL)
@@ -3065,27 +3069,37 @@ static void decl_enum(int vclass,int fstatic)
     sym=add_constant(constname,value,vclass,tag);
     if (sym==NULL)
       continue;                         /* error message already given */
-    /* set the item tag and the item size, for use in indexing arrays */
-    sym->x.tags.index=idxtag;
-    sym->x.tags.field=fieldtag;
-    sym->dim.array.length=size;
-    sym->dim.array.level=0;
-    sym->parent=enumsym;
-    if (enumsym)
-      enumsym->child=sym;
-    if (vclass==sLOCAL)
-      sym->compound=pc_nestlevel;
+    /* modify the symbol only if it's not the current enum root symbol
+     * being redefined by the user */
+    if (sym!=enumsym) {
+      /* clear the "enum root" flag and delete the list of enum elements,
+       * in case we redefined a root symbol of another enum */
+      if ((sym->usage & uENUMROOT)!=0) {
+        sym->usage &= ~uENUMROOT;
+        delete_consttable(sym->dim.enumlist);
+      } /* if */
+      /* set the item tag and the item size, for use in indexing arrays */
+      sym->x.tags.index=idxtag;
+      sym->x.tags.field=fieldtag;
+      sym->dim.array.length=size;
+      sym->dim.array.level=0;
+      sym->parent=enumsym;
+      if (enumsym)
+        enumsym->child=sym;
+      if (vclass==sLOCAL)
+        sym->compound=pc_nestlevel;
 
-    if (fstatic)
-      sym->fnumber=filenum;
+      if (fstatic)
+        sym->fnumber=filenum;
 
-    if (enumroot!=NULL && find_constval_byval(enumroot,value)==NULL)
-      unique++;
+      if (enumroot!=NULL && find_constval_byval(enumroot,value)==NULL)
+        unique++;
 
-    /* add the constant to a separate list as well */
-    if (enumroot!=NULL) {
-      sym->usage |= uENUMFIELD;
-      append_constval(enumroot,constname,value,tag);
+      /* add the constant to a separate list as well */
+      if (enumroot!=NULL) {
+        sym->usage |= uENUMFIELD;
+        append_constval(enumroot,constname,value,tag);
+      } /* if */
     } /* if */
     if (inctok==taADD) {
       value+=size;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5344,7 +5344,7 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag)
     if (redef) {
       error(21,name);           /* symbol already defined */
       return NULL;
-    } else if (sym->addr!=val) {
+    } else if (sym->addr!=val || (sym->usage & uENUMROOT)!=0) {
       error(201,name);          /* redefinition of constant (different value) */
       sym->addr=val;            /* set new value */
     } /* if */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3086,8 +3086,6 @@ static void decl_enum(int vclass,int fstatic)
       sym->parent=enumsym;
       if (enumsym)
         enumsym->child=sym;
-      if (vclass==sLOCAL)
-        sym->compound=pc_nestlevel;
 
       if (fstatic)
         sym->fnumber=filenum;

--- a/source/compiler/tests/gh_403.meta
+++ b/source/compiler/tests/gh_403.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_403.pwn(3) : warning 201: redefinition of constant/macro (symbol "test1")
+gh_403.pwn(10) : warning 201: redefinition of constant/macro (symbol "test2")
+gh_403.pwn(18) : warning 201: redefinition of constant/macro (symbol "test3")
+"""
+}

--- a/source/compiler/tests/gh_403.pwn
+++ b/source/compiler/tests/gh_403.pwn
@@ -1,0 +1,20 @@
+// Case 1: The compiler should warn us if we are redefining an empty named enum
+enum test1 {};
+enum test1 {}; // warning 201: redefinition of constant/macro (symbol "test1")
+
+// Case 2: The compiler shouldn't crash because of "test2" being redefined
+enum _:test2 {};
+enum
+{
+    test2 // warning 201: redefinition of constant/macro (symbol "test2")
+};
+
+// Case 3: The compiler shouldn't crash because of "test3" being redefined
+// (this is different from case 2 since we're redefining the root symbol
+// of the current enum, not of another one)
+enum _:test3
+{
+	test3 // warning 201: redefinition of constant/macro (symbol "test3")
+};
+
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does the following:
* Fixes crash when an enum root symbol is redefined by an enum constant (#403).
* Fixes the compiler not warning when redefining a root symbol of an empty named enum (#575).

**Which issue(s) this PR fixes**:

Fixes #403, #575

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: