### PR TITLE
Compare the contents of default arrays between function declaration(s) and implementation

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4048,9 +4048,8 @@ static int argcompare(arginfo *a1,arginfo *a2)
         result= a1->defvalue.array.size==a2->defvalue.array.size;
       if (result)
         result= a1->defvalue.array.arraysize==a2->defvalue.array.arraysize;
-      /* ??? should also check contents of the default array (these troubles
-       * go away in a 2-pass compiler that forbids double declarations, but
-       * Pawn currently does not forbid them) */
+      if (result)
+        result=(memcmp(a1->defvalue.array.data,a2->defvalue.array.data,a1->defvalue.array.size*sizeof(cell))==0);
     } else {
       if (result) {
         if ((a1->hasdefault & uSIZEOF)!=0 || (a1->hasdefault & uTAGOF)!=0)

--- a/source/compiler/tests/array_defvalue.meta
+++ b/source/compiler/tests/array_defvalue.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+array_defvalue.pwn(5) : error 025: function heading differs from prototype
+array_defvalue.pwn(8) : error 025: function heading differs from prototype
+array_defvalue.pwn(10) : error 025: function heading differs from prototype
+  """
+}

--- a/source/compiler/tests/array_defvalue.pwn
+++ b/source/compiler/tests/array_defvalue.pwn
@@ -1,0 +1,15 @@
+#pragma warning disable 218 // "old style prototypes used with optional semicolumns"
+forward Func(const a[] = { 1, 2, 3 }); // original declaration
+
+forward Func(const a[] = { 1, 2, 3 });
+forward Func(const a[] = { 2, 3, 4 }); // error 025
+
+stock Func(const a[] = { 1, 2, 3 });
+stock Func(const a[] = { 2, 3, 4 }); // error 025
+
+stock Func(const a[] = { 3, 4, 5 }) // error 025
+{
+	return a[0];
+}
+
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the compiler not warning when default values of array arguments differ between declaration(s) and implementation (see #576).

**Which issue(s) this PR fixes**:

Fixes #576

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: