### PR TITLE
Misc. minor fixes and adjustments

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -509,7 +509,7 @@ enum {
 enum {
   sOPTIMIZE_NONE,               /* no optimization */
   sOPTIMIZE_NOMACRO,            /* no macro instructions */
-  sOPTIMIZE_DEFAULT,            /* full optimization */
+  sOPTIMIZE_FULL,               /* full optimization */
   /* ----- */
   sOPTIMIZE_NUMBER
 };

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -639,7 +639,7 @@ void *pc_openasm(char *filename); /* read/write */
 void pc_closeasm(void *handle,int deletefile);
 void pc_resetasm(void *handle);
 int  pc_writeasm(void *handle,char *str);
-char *pc_readasm(void *handle,char *target,int maxchars);
+char *pc_readasm(void *handle,char *string,int maxchars);
 
 /* output to binary (.AMX) file */
 void *pc_openbin(char *filename);
@@ -711,7 +711,7 @@ SC_FUNC void litinsert(cell value,int pos);
 SC_FUNC int alphanum(char c);
 SC_FUNC int ishex(char c);
 SC_FUNC void delete_symbol(symbol *root,symbol *sym);
-SC_FUNC void delete_symbols(symbol *root,int level,int del_labels,int delete_functions);
+SC_FUNC void delete_symbols(symbol *root,int level,int delete_labels,int delete_functions);
 SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom);
 SC_FUNC void markusage(symbol *sym,int usage);
 SC_FUNC void markinitialized(symbol *sym,int assignment);
@@ -721,7 +721,7 @@ SC_FUNC void restoreassignments(int fromlevel,assigninfo *assignments);
 SC_FUNC void rename_symbol(symbol *sym,const char *newname);
 SC_FUNC symbol *findglb(const char *name,int filter);
 SC_FUNC symbol *findloc(const char *name);
-SC_FUNC symbol *findconst(const char *name,int *matchtag);
+SC_FUNC symbol *findconst(const char *name,int *cmptag);
 SC_FUNC symbol *finddepend(const symbol *parent);
 SC_FUNC symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,
                        int usage);
@@ -749,14 +749,14 @@ SC_FUNC void setfiledirect(char *name);
 SC_FUNC void setfileconst(char *name);
 SC_FUNC void setlinedirect(int line);
 SC_FUNC void setlineconst(int line);
-SC_FUNC void setlabel(int index);
+SC_FUNC void setlabel(int number);
 SC_FUNC void markexpr(optmark type,const char *name,cell offset);
 SC_FUNC void startfunc(char *fname,int generateproc);
 SC_FUNC void endfunc(void);
 SC_FUNC void alignframe(int numbytes);
 SC_FUNC void rvalue(value *lval);
 SC_FUNC void dereference(void);
-SC_FUNC void address(symbol *ptr,regid reg);
+SC_FUNC void address(symbol *sym,regid reg);
 SC_FUNC void store(value *lval);
 SC_FUNC void loadreg(cell address,regid reg);
 SC_FUNC void storereg(cell address,regid reg);
@@ -833,7 +833,7 @@ SC_FUNC void outinstr(const char *name,emit_outval params[],int numparams);
 /* function prototypes in SC5.C */
 SC_FUNC int error(long number,...);
 SC_FUNC void errorset(int code,int line);
-SC_FUNC int error_suggest(int error,const char *name,const char *name2,int type,int subtype);
+SC_FUNC int error_suggest(int number,const char *name,const char *name2,int type,int subtype);
 
 /* function prototypes in SC6.C */
 SC_FUNC int assemble(FILE *fout,FILE *fin);
@@ -841,7 +841,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin);
 /* function prototypes in SC7.C */
 SC_FUNC void stgbuffer_cleanup(void);
 SC_FUNC void stgmark(char mark);
-SC_FUNC void stgwrite(const char *st);
+SC_FUNC void stgwrite(const char *str);
 SC_FUNC void stgout(int index);
 SC_FUNC void stgdel(int index,cell code_index);
 SC_FUNC int stgget(int *index,cell *code_index);

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -608,10 +608,10 @@ int pc_compile(int argc, char **argv);
 int pc_addconstant(char *name,cell value,int tag);
 int pc_addtag(char *name);
 int pc_enablewarning(int number,int enable);
-int pc_pushwarnings();
-int pc_popwarnings();
+int pc_pushwarnings(void);
+int pc_popwarnings(void);
 void pc_seterrorwarnings(int enable);
-int pc_geterrorwarnings();
+int pc_geterrorwarnings(void);
 
 /*
  * Functions called from the compiler (to be implemented by you)

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3233,7 +3233,7 @@ SC_FUNC symbol *fetchfunc(char *name,int tag)
 {
   symbol *sym;
 
-  if ((sym=findglb(name,sGLOBAL))!=0) {   /* already in symbol table? */
+  if ((sym=findglb(name,sGLOBAL))!=NULL) {/* already in symbol table? */
     if (sym->ident!=iFUNCTN) {
       error(21,name);                     /* yes, but not as a function */
       return NULL;                        /* make sure the old symbol is not damaged */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1116,7 +1116,11 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         break;
 #if defined	__WIN32__ || defined _WIN32 || defined _Windows
       case 'H':
-        hwndFinish=(HWND)atoi(option_value(ptr));
+        #if defined __64BIT__
+          hwndFinish=(HWND)atoll(option_value(ptr));
+        #else
+          hwndFinish=(HWND)atoi(option_value(ptr));
+        #endif
         if (!IsWindow(hwndFinish))
           hwndFinish=(HWND)0;
         break;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -92,10 +92,10 @@ static void dumplits(void);
 static void dumpzero(int count);
 static void declfuncvar(int fpublic,int fstatic,int fstock,int fconst);
 static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,
-                    int stock,int fconst);
+                    int fstock,int fconst);
 static int declloc(int fstatic);
-static void decl_const(int table);
-static void decl_enum(int table,int fstatic);
+static void decl_const(int vclass);
+static void decl_enum(int vclass,int fstatic);
 static cell needsub(int *tag,constvalue_root **enumroot);
 static void initials(int ident,int tag,cell *size,int dim[],int numdim,
                      constvalue_root *enumroot,int *explicit_init);
@@ -1489,10 +1489,10 @@ static void about(void)
   longjmp(errbuf,3);        /* user abort */
 }
 
-static void invalid_option(const char *optptr)
+static void invalid_option(const char *opt)
 {
   usage();
-  pc_printf("\nInvalid or unsupported option: -%s\n",optptr);
+  pc_printf("\nInvalid or unsupported option: -%s\n",opt);
   longjmp(errbuf,3);        /* user abort */
 }
 

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1615,7 +1615,7 @@ static void setconstants(void)
   append_constval(&sc_automaton_tab,"",0,0);    /* anonymous automaton */
 }
 
-static void setstringconstants()
+static void setstringconstants(void)
 {
   time_t now;
   char timebuf[arraysize("11:22:33")];

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2475,7 +2475,8 @@ static int declloc(int fstatic)
       sym->usage |= uREAD;
     if (matchtoken(t__PRAGMA))
       dopragma();
-    pragma_apply(sym);  } while (matchtoken(',')); /* enddo */   /* more? */
+    pragma_apply(sym);
+  } while (matchtoken(',')); /* enddo */   /* more? */
   needtoken(tTERM);    /* if not comma, must be semicolumn */
   return ident;
 }

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -787,7 +787,7 @@ static int ftoi(cell *val,const unsigned char *curptr)
     /* floating point */
     #if PAWN_CELL_SIZE==32
       float value=(float)fnum;
-      assert_static(sizeof(val)==sizeof(value));
+      assert_static(sizeof(*val)==sizeof(value));
       *val=*((cell *)&value);
       #if !defined NDEBUG
         /* I assume that the C/C++ compiler stores "float" values in IEEE 754
@@ -806,7 +806,7 @@ static int ftoi(cell *val,const unsigned char *curptr)
         }
       #endif
     #elif PAWN_CELL_SIZE==64
-      assert_static(sizeof(val)==sizeof(fnum));
+      assert_static(sizeof(*val)==sizeof(fnum));
       *val=*((cell *)&fnum);
       #if !defined NDEBUG
         /* I assume that the C/C++ compiler stores "double" values in IEEE 754

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -226,7 +226,7 @@ SC_FUNC int plungefile(char *name,int try_currentpath,int try_includepaths)
        * there is a (relative) path for the current file
        */
       char *ptr;
-      if ((ptr=strrchr(inpfname,dirsep))!=0) {
+      if ((ptr=strrchr(inpfname,dirsep))!=NULL) {
         int len=(int)(ptr-inpfname)+1;
         if (len+strlen(name)<_MAX_PATH) {
           char path[_MAX_PATH];

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3184,7 +3184,7 @@ SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom)
 SC_FUNC void markusage(symbol *sym,int usage)
 {
   assert(sym!=NULL);
-  sym->usage |= (char)usage;
+  sym->usage |= (short)usage;
   if ((usage & uWRITTEN)!=0)
     sym->lnumber=fline;
   if ((usage & uREAD)!=0 && (sym->ident==iVARIABLE || sym->ident==iREFERENCE))
@@ -3388,7 +3388,7 @@ SC_FUNC symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,i
   entry.vclass=(char)vclass;
   entry.ident=(char)ident;
   entry.tag=tag;
-  entry.usage=(char)usage;
+  entry.usage=(short)usage;
   entry.assignlevel=0;
   entry.fnumber=-1;     /* assume global visibility (ignored for local symbols) */
   entry.lnumber=fline;

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1963,7 +1963,7 @@ SC_FUNC void preprocess(void)
 static const unsigned char *unpackedstring(const unsigned char *lptr,int *flags)
 {
   const unsigned char *stringize;
-  int instring=1;
+  int instring=TRUE;
   int brackets=0;
   if (*flags & STRINGIZE)                 /* ignore leading spaces after the # */
     while (*lptr==' ' || *lptr=='\t')     /* this is as defines with parameters may add them */
@@ -1975,11 +1975,11 @@ static const unsigned char *unpackedstring(const unsigned char *lptr,int *flags)
     } /* if */
     if (!instring) {
       if (*lptr=='\"') {
-        instring=1;
+        instring=TRUE;
       } else if (*lptr=='#') {
         while (*++lptr==' ' || *lptr=='\t');
         lptr--;
-        instring=1;
+        instring=TRUE;
         *flags |= STRINGIZE;
         brackets=0;
       } else if (*lptr==')' || *lptr==',' || *lptr=='}' || *lptr==';' ||
@@ -2024,7 +2024,7 @@ static const unsigned char *unpackedstring(const unsigned char *lptr,int *flags)
     } else {
       if (*lptr=='\"') {
         stringize=lptr++;
-        instring=0;
+        instring=FALSE;
         continue;
       } /* if (*flags & STRINGIZE) */
     }
@@ -2043,7 +2043,7 @@ static const unsigned char *packedstring(const unsigned char *lptr,int *flags)
   int i;
   ucell val,c;
   const unsigned char *stringize;
-  int instring=1;
+  int instring=TRUE;
   int brackets=0;
   if (*flags & STRINGIZE)
     while (*lptr==' ' || *lptr=='\t')
@@ -2058,11 +2058,11 @@ static const unsigned char *packedstring(const unsigned char *lptr,int *flags)
     } /* if */
     if (!instring) {
       if (*lptr=='\"') {
-        instring=1;
+        instring=TRUE;
       } else if (*lptr=='#') {
         while (*++lptr==' ' || *lptr=='\t');
         lptr--;
-        instring=1;
+        instring=TRUE;
         brackets=0;
         *flags |= STRINGIZE;
       } else if (*lptr==')' || *lptr==',' || *lptr=='}' || *lptr==';' ||
@@ -2107,7 +2107,7 @@ static const unsigned char *packedstring(const unsigned char *lptr,int *flags)
     } else {
       if (*lptr=='\"') {
         stringize=lptr++;
-        instring=0;
+        instring=FALSE;
         continue;
       } /* if (*flags & STRINGIZE) */
     }
@@ -2287,14 +2287,14 @@ SC_FUNC int lex(cell *lexvalue,char **lexsym)
      */
     _lextok=tSYMBOL;
     i=0;
-    toolong=0;
+    toolong=FALSE;
     while (alphanum(*lptr)){
       _lexstr[i]=*lptr;
       lptr+=1;
       if (i<sNAMEMAX)
         i+=1;
       else
-        toolong=1;
+        toolong=TRUE;
     } /* while */
     _lexstr[i]='\0';
     if (toolong)

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3184,7 +3184,7 @@ SC_FUNC int refer_symbol(symbol *entry,symbol *bywhom)
 SC_FUNC void markusage(symbol *sym,int usage)
 {
   assert(sym!=NULL);
-  sym->usage |= (short)usage;
+  sym->usage |= (short)(unsigned short)usage;
   if ((usage & uWRITTEN)!=0)
     sym->lnumber=fline;
   if ((usage & uREAD)!=0 && (sym->ident==iVARIABLE || sym->ident==iREFERENCE))
@@ -3388,7 +3388,7 @@ SC_FUNC symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,i
   entry.vclass=(char)vclass;
   entry.ident=(char)ident;
   entry.tag=tag;
-  entry.usage=(short)usage;
+  entry.usage=(short)(unsigned short)usage;
   entry.assignlevel=0;
   entry.fnumber=-1;     /* assume global visibility (ignored for local symbols) */
   entry.lnumber=fline;

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -701,9 +701,9 @@ static cell calc(cell left,void (*oper)(),cell right,char *boolresult)
   else if (oper==os_mult)
     return (left * right);
   else if (oper==os_div)
-    return flooreddiv(left,right,0);
+    return flooreddiv(left,right,FALSE);
   else if (oper==os_mod)
-    return flooreddiv(left,right,1);
+    return flooreddiv(left,right,TRUE);
   else
     error(29);  /* invalid expression, assumed 0 (this should never occur) */
   return 0;

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1973,7 +1973,7 @@ static int primary(value *lval)
   } /* if */
   if (tok==tSYMBOL && !findconst(st,NULL)) {
     /* first look for a local variable */
-    if ((sym=findloc(st))!=0) {
+    if ((sym=findloc(st))!=NULL) {
       if (sym->ident==iLABEL) {
         error(29);          /* expression error, assumed 0 */
         ldconst(0,sPRI);    /* load 0 */
@@ -1992,7 +1992,7 @@ static int primary(value *lval)
       } /* if */
     } /* if */
     /* now try a global variable */
-    if ((sym=findglb(st,sSTATEVAR))!=0) {
+    if ((sym=findglb(st,sSTATEVAR))!=NULL) {
       if (sym->ident==iFUNCTN || sym->ident==iREFFUNC) {
         /* if the function is only in the table because it was inserted as a
          * stub in the first pass (i.e. it was "used" but never declared or
@@ -2655,7 +2655,7 @@ static int constant(value *lval)
   int cmptag=lval->cmptag;
 
   tok=lex(&val,&st);
-  if (tok==tSYMBOL && (sym=findconst(st,&cmptag))!=0) {
+  if (tok==tSYMBOL && (sym=findconst(st,&cmptag))!=NULL) {
     if (cmptag>1)
       error(91,sym->name);  /* ambiguity: multiple matching constants (different tags) */
     lval->constval=sym->addr;

--- a/source/compiler/sc4.c
+++ b/source/compiler/sc4.c
@@ -836,7 +836,7 @@ SC_FUNC void defstorage(void)
  *  Same as defstorage() but for repeating values.
  */
 
-SC_FUNC void defcompactstorage()
+SC_FUNC void defcompactstorage(void)
 {
   stgwrite("dumpn ");
 }

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -416,7 +416,7 @@ int pc_enablewarning(int number,int enable)
 /* pc_pushwarnings()
  * Saves currently disabled warnings, used to implement #pragma warning push
  */
-int pc_pushwarnings()
+int pc_pushwarnings(void)
 {
   void *p;
   p=calloc(sizeof(struct s_warnstack),1);
@@ -432,7 +432,7 @@ int pc_pushwarnings()
 /* pc_popwarnings()
  * This function is the reverse of pc_pushwarnings()
  */
-int pc_popwarnings()
+int pc_popwarnings(void)
 {
   void *p;
   if (warnstack.next==NULL)
@@ -451,7 +451,7 @@ void pc_seterrorwarnings(int enable)
   errwarn = enable;
 }
 
-int pc_geterrorwarnings()
+int pc_geterrorwarnings(void)
 {
   return errwarn;
 }

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -316,7 +316,7 @@ static void write_encoded_n(FILE *fbin,ucell c,int num)
     while (num-->0)
       writeerror |= !pc_writebin(fbin,bytes,len);
   } else {
-    c=aligncell(c);
+    (void)aligncell(&c);
     while (num-->0) {
       assert((pc_lengthbin(fbin) % sizeof(cell)) == 0);
       writeerror |= !pc_writebin(fbin,&c,sizeof c);

--- a/source/compiler/sc7.c
+++ b/source/compiler/sc7.c
@@ -1465,7 +1465,7 @@ static int stgstring(char *start,char *end)
   char *ptr;
   int nest,argc,arg;
   argstack *stack;
-  int reordered=0;
+  int reordered=FALSE;
 
   while (start<end) {
     if (*start==sSTARTREORDER) {
@@ -1474,7 +1474,7 @@ static int stgstring(char *start,char *end)
       stack=(argstack *)malloc(sMAXARGS*sizeof(argstack));
       if (stack==NULL)
         error(103);     /* insufficient memory */
-      reordered=1;      /* mark that the expression is reordered */
+      reordered=TRUE;   /* mark that the expression is reordered */
       nest=1;           /* nesting counter */
       argc=0;           /* argument counter */
       arg=-1;           /* argument index; no valid argument yet */

--- a/source/compiler/sc7.c
+++ b/source/compiler/sc7.c
@@ -1365,23 +1365,23 @@ static int filewrite(char *str)
  *                     staging (referred to only)
  *                     stglen  (altered)
  */
-SC_FUNC void stgwrite(const char *st)
+SC_FUNC void stgwrite(const char *str)
 {
   int len;
-  int st_len=strlen(st);
+  int st_len=strlen(str);
 
   if (staging) {
     assert(stgidx==0 || stgbuf!=NULL);  /* staging buffer must be valid if there is (apparently) something in it */
     if (stgidx>=2 && stgbuf[stgidx-1]=='\0' && stgbuf[stgidx-2]!='\n')
       stgidx-=1;                        /* overwrite last '\0' */
     CHECK_STGBUFFER(stgidx+st_len+1);
-    memcpy(stgbuf+stgidx,st,st_len+1);  /* copy to staging buffer */
+    memcpy(stgbuf+stgidx,str,st_len+1); /* copy to staging buffer */
     stgidx+=st_len+1;
     stglen+=st_len;
   } else {
     len=(stgbuf!=NULL) ? stglen : 0;
     CHECK_STGBUFFER(len+st_len+1);
-    memcpy(stgbuf+len,st,st_len+1);
+    memcpy(stgbuf+len,str,st_len+1);
     len=len+st_len;
     stglen=len;
     if (len>0 && stgbuf[len-1]=='\n') {

--- a/source/compiler/scstate.c
+++ b/source/compiler/scstate.c
@@ -136,16 +136,16 @@ static constvalue *find_state(const char *name,int fsa,int *last)
   return NULL;
 }
 
-SC_FUNC constvalue *state_add(const char *name,int fsa)
+SC_FUNC constvalue *state_add(const char *name,int fsa_id)
 {
   constvalue *ptr;
   int last;
 
   assert(strlen(name)<arraysize(ptr->name));
-  ptr=find_state(name,fsa,&last);
+  ptr=find_state(name,fsa_id,&last);
   if (ptr==NULL) {
-    assert(fsa <= SHRT_MAX);
-    ptr=append_constval(&sc_state_tab,name,(cell)(last+1),(short)fsa);
+    assert(fsa_id <= SHRT_MAX);
+    ptr=append_constval(&sc_state_tab,name,(cell)(last+1),(short)fsa_id);
   } /* if */
   return ptr;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does the following:
* Fixes a typo that resulted in `sizeof` being used on a pointer.
  The typo itself doesn't pose a problem for 32-bit builds, since the cell and pointer sizes are the same there, but it triggers `assert_static()` when building for 64-bit platforms.
* Fixes potential pointer truncation for the `-H` parameter on 64-bit builds.
* Fixes `0` being used instead of `NULL` and `FALSE` in a few places.
* Fixes inconsistent parameter naming between function declarations and implementations.
* Fixes invalid use of macro `aligncell()` (`sc6.c`).
* Renames optimization mode `sOPTIMIZE_DEFAULT` into `sOPTIMIZE_FULL` (see https://github.com/pawn-lang/compiler/issues/296#issuecomment-703054266).
* Other cosmetic fixes and adjustments that don't deserve a separate PR.


**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
