### PR TITLE
Improvements for detection of unreachable code

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -469,6 +469,8 @@ enum {
   /* for assigment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */
+  tTERMINAL,/* all "if" branches or "switch" cases end with
+             * terminal statements ("return", "break" etc.) */
 };
 
 /* (reversed) evaluation of staging buffer */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -469,17 +469,17 @@ enum {
   /* for assigment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */
-  tTERMINAL,/* signalizes that the code after this statement is unreachable,
-             * which can happen when:
-             *  * both 'if' branches end with different kinds of "terminal"
-             *    statements, such as 'return', 'break', 'continue' or endless
-             *    loop;
-             *  * all 'switch' cases (including 'default') end with terminal
-             *    statements;
-             *  * a 'goto' is used on an already implemented label (which has
-             *    the 'uDEFINE' flag set) and there are no undefined labels
-             *    ("declared" through 'goto', but not implemented yet)
-             */
+  tTERMINAL, /* signalizes that the code after this statement is unreachable,
+              * which can happen when:
+              *  * both 'if' branches end with different kinds of "terminal"
+              *    statements, such as 'return', 'break', 'continue' or endless
+              *    loop;
+              *  * a 'goto' is used on an already implemented label (which has
+              *    the 'uDEFINE' flag set) and there are no undefined labels
+              *    ("declared" through 'goto', but not implemented yet)
+              */
+  tTERMSWITCH, /* signalizes that all 'switch' cases (including 'default') end
+                * with terminal statements; */
 };
 
 /* (reversed) evaluation of staging buffer */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -469,8 +469,17 @@ enum {
   /* for assigment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */
-  tTERMINAL,/* all "if" branches or "switch" cases end with
-             * terminal statements ("return", "break" etc.) */
+  tTERMINAL,/* signalizes that the code after this statement is unreachable,
+             * which can happen when:
+             *  * both 'if' branches end with different kinds of "terminal"
+             *    statements, such as 'return', 'break', 'continue' or endless
+             *    loop;
+             *  * all 'switch' cases (including 'default') end with terminal
+             *    statements;
+             *  * a 'goto' is used on an already implemented label (which has
+             *    the 'uDEFINE' flag set) and there are no undefined labels
+             *    ("declared" through 'goto', but not implemented yet)
+             */
 };
 
 /* (reversed) evaluation of staging buffer */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5623,8 +5623,8 @@ static void compound(int stmt_sameline,int starttok)
           tokeninfo(&val,&name);
           lexpush();            /* push the token so it can be analyzed later */
           sym=findloc(name);
-          assert(sym!=NULL);
-          if ((sym->usage & uREAD)==0)  /* label wasn't previously used via 'goto' */
+          /* before issuing a warning, check if the label was previously used (via 'goto') */
+          if (sym!=NULL && sym->ident==iLABEL && (sym->usage & uREAD)==0)
             error(225);         /* unreachable code */
         } else if (lastst==tTERMSWITCH && matchtoken(tRETURN)) {
           lexpush();            /* push the token so it can be analyzed later */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -7829,7 +7829,7 @@ static int isvariadic(symbol *sym)
 static int isterminal(int tok)
 {
   return (tok==tRETURN || tok==tBREAK || tok==tCONTINUE || tok==tENDLESS
-          || tok==tTERMINAL || tok==tTERMSWITCH);
+          || tok==tEXIT || tok==tTERMINAL || tok==tTERMSWITCH);
 }
 
 /*  doreturn

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3972,7 +3972,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
     modstk((int)declared*sizeof(cell)); /* remove all local variables */
     declared=0;
   } /* if */
-  if ((lastst!=tRETURN) && (lastst!=tGOTO) && (sym->flags & flagNAKED)==0) {
+  if (!isterminal(lastst) && lastst!=tGOTO && (sym->flags & flagNAKED)==0) {
     destructsymbols(&loctab,0);
     ldconst(0,sPRI);
     ffret(strcmp(sym->name,uENTRYFUNC)!=0);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5806,6 +5806,7 @@ static int doif(void)
   int returnst=tIF;
   assigninfo *assignments=NULL;
 
+  lastst=0;                     /* reset the last statement */
   ifindent=stmtindent;          /* save the indent of the "if" instruction */
   flab1=getlabel();             /* get label number for false branch */
   test(flab1,TEST_THEN,FALSE);  /* get expression, branch to flab1 if false */
@@ -5814,6 +5815,7 @@ static int doif(void)
     setlabel(flab1);            /* no, simple if..., print false label */
   } else {
     lastst_true=lastst;         /* save last statement of the "true" branch */
+    lastst=0;                   /* reset the last statement */
     /* to avoid the "dangling else" error, we want a warning if the "else"
      * has a lower indent than the matching "if" */
     if (stmtindent<ifindent && sc_tabsize>0)
@@ -5829,7 +5831,7 @@ static int doif(void)
      * kind of statement, set the last statement id to that kind, rather than
      * to the generic tIF; this allows for better "unreachable code" checking
      */
-    if (lastst==lastst_true)
+    if (lastst==lastst_true && lastst!=0)
       returnst=lastst;
     /* otherwise, if both branches end with terminal statements (not necessary
      * of the same kind), set the last statement ID to tTERMINAL */
@@ -6061,6 +6063,7 @@ static int doswitch(void)
     tok=lex(&val,&str);         /* read in (new) token */
     switch (tok) {
     case tCASE:
+      lastst=0;
       if (casecount!=0)
         memoizeassignments(pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)
@@ -6138,6 +6141,7 @@ static int doswitch(void)
       allterminal &= isterminal(lastst);
       break;
     case tDEFAULT:
+      lastst=0;
       if (casecount!=0)
         memoizeassignments(pc_nestlevel+1,&assignments);
       if (swdefault!=FALSE)

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5616,7 +5616,19 @@ static void compound(int stmt_sameline,int starttok)
       break;
     } else {
       if (count_stmt>0 && isterminal(lastst))
-        error(225);             /* unreachable code */
+        if (matchtoken(tLABEL)) {
+          cell val;
+          char *name;
+          symbol *sym;
+          tokeninfo(&val,&name);
+          lexpush();            /* push the token so it can be analyzed later */
+          sym=findloc(name);
+          assert(sym!=NULL);
+          if ((sym->usage & uREAD)==0)  /* label wasn't previously used via 'goto' */
+            error(225);         /* unreachable code */
+        } else {
+          error(225);           /* unreachable code */
+        } /* if */
       statement(&indent,TRUE);  /* do a statement */
       count_stmt++;
     } /* if */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -133,6 +133,7 @@ static int dofor(void);
 static void doswitch(void);
 static void dogoto(void);
 static void dolabel(void);
+static int isterminal(int tok);
 static void doreturn(void);
 static void dobreak(void);
 static void docont(void);
@@ -5616,7 +5617,7 @@ static void compound(int stmt_sameline,int starttok)
       error(30,block_start);    /* compound block not closed at end of file */
       break;
     } else {
-      if (count_stmt>0 && (lastst==tRETURN || lastst==tBREAK || lastst==tCONTINUE || lastst==tENDLESS))
+      if (count_stmt>0 && isterminal(lastst))
         error(225);             /* unreachable code */
       statement(&indent,TRUE);  /* do a statement */
       count_stmt++;
@@ -5831,6 +5832,10 @@ static int doif(void)
      */
     if (lastst==lastst_true)
       returnst=lastst;
+    /* otherwise, if both branches end with terminal statements (not necessary
+     * of the same kind), set the last statement ID to tTERMINAL */
+    else if (isterminal(lastst_true) && isterminal(lastst))
+      returnst=tTERMINAL;
   } /* if */
   restoreassignments(pc_nestlevel+1,assignments);
   return returnst;
@@ -7783,6 +7788,15 @@ static int isvariadic(symbol *sym)
     } /* if */
   } /* for */
   return FALSE;
+}
+
+/* isterminal
+ *
+ * Checks if the token represents one of the terminal kinds of statements.
+ */
+static int isterminal(int tok)
+{
+  return (tok==tRETURN || tok==tBREAK || tok==tCONTINUE || tok==tENDLESS || tok==tTERMINAL);
 }
 
 /*  doreturn

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -3,7 +3,7 @@
   'errors': """
 unreachable_code.pwn(12) : warning 225: unreachable code
 unreachable_code.pwn(24) : warning 225: unreachable code
-unreachable_code.pwn(39) : warning 225: unreachable code
-unreachable_code.pwn(54) : warning 225: unreachable code
+unreachable_code.pwn(57) : warning 225: unreachable code
+unreachable_code.pwn(72) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -3,5 +3,7 @@
   'errors': """
 unreachable_code.pwn(12) : warning 225: unreachable code
 unreachable_code.pwn(24) : warning 225: unreachable code
+unreachable_code.pwn(39) : warning 225: unreachable code
+unreachable_code.pwn(54) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -5,5 +5,6 @@ unreachable_code.pwn(12) : warning 225: unreachable code
 unreachable_code.pwn(24) : warning 225: unreachable code
 unreachable_code.pwn(66) : warning 225: unreachable code
 unreachable_code.pwn(81) : warning 225: unreachable code
+unreachable_code.pwn(111) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+unreachable_code.pwn(12) : warning 225: unreachable code
+unreachable_code.pwn(24) : warning 225: unreachable code
+"""
+}

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -3,7 +3,7 @@
   'errors': """
 unreachable_code.pwn(12) : warning 225: unreachable code
 unreachable_code.pwn(24) : warning 225: unreachable code
-unreachable_code.pwn(57) : warning 225: unreachable code
-unreachable_code.pwn(72) : warning 225: unreachable code
+unreachable_code.pwn(66) : warning 225: unreachable code
+unreachable_code.pwn(81) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -3,8 +3,8 @@
   'errors': """
 unreachable_code.pwn(12) : warning 225: unreachable code
 unreachable_code.pwn(24) : warning 225: unreachable code
-unreachable_code.pwn(66) : warning 225: unreachable code
-unreachable_code.pwn(81) : warning 225: unreachable code
-unreachable_code.pwn(111) : warning 225: unreachable code
+unreachable_code.pwn(67) : warning 225: unreachable code
+unreachable_code.pwn(82) : warning 225: unreachable code
+unreachable_code.pwn(127) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.meta
+++ b/source/compiler/tests/unreachable_code.meta
@@ -6,5 +6,6 @@ unreachable_code.pwn(24) : warning 225: unreachable code
 unreachable_code.pwn(67) : warning 225: unreachable code
 unreachable_code.pwn(82) : warning 225: unreachable code
 unreachable_code.pwn(127) : warning 225: unreachable code
+unreachable_code.pwn(167) : warning 225: unreachable code
 """
 }

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -131,6 +131,20 @@ label_1:
 	// shouldn't cause warning 209 ("function should return a value")
 }
 
+test_goto_4()
+{
+	new var = 0;
+	if (var == 0)
+		goto label_1;
+	if (var != 0)
+		return 0;
+	else
+		return 1;
+	// shouldn't cause warning 225 ("unreachable code")
+label_1:
+	return 2;
+}
+
 main()
 {
 	test_if_1();
@@ -145,4 +159,5 @@ main()
 	test_goto_1();
 	test_goto_2();
 	test_goto_3();
+	test_goto_4();
 }

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -25,6 +25,24 @@ test_if_2()
 	}
 }
 
+test_if_3()
+{
+	if (g_var != 0)
+		return 0;
+	else
+		return 1;
+	// shouldn't cause warning 209 ("function should return a value")
+}
+
+test_if_4()
+{
+	if (g_var != 0)
+		return 0;
+	else
+		for (;;) {}
+	// shouldn't cause warning 209 ("function should return a value")
+}
+
 test_switch_1()
 {
 	switch (g_var)
@@ -69,11 +87,22 @@ test_switch_3()
 	return 2;
 }
 
+test_endless()
+{
+	if (g_var != 0)
+		return 0;
+	for (;;) {}
+	// shouldn't cause warning 209 ("function should return a value")
+}
+
 main()
 {
 	test_if_1();
 	test_if_2();
+	test_if_3();
+	test_if_4();
 	test_switch_1();
 	test_switch_2();
 	test_switch_3();
+	test_endless();
 }

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -43,6 +43,15 @@ test_if_4()
 	// shouldn't cause warning 209 ("function should return a value")
 }
 
+test_if_5()
+{
+	if (g_var != 0)
+		return 1;
+	else
+		{}
+	return 1;
+}
+
 test_switch_1()
 {
 	switch (g_var)
@@ -101,6 +110,7 @@ main()
 	test_if_2();
 	test_if_3();
 	test_if_4();
+	test_if_5();
 	test_switch_1();
 	test_switch_2();
 	test_switch_3();

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -25,8 +25,55 @@ test_if_2()
 	}
 }
 
+test_switch_1()
+{
+	switch (g_var)
+	{
+		case 0:
+			return 0;
+		case 1:
+			return 1;
+		default:
+			return 2;
+	}
+	return 3; // warning 225: unreachable code
+}
+
+test_switch_2()
+{
+	new i = 0;
+	while (i < 10)
+	{
+		switch (g_var)
+		{
+			case 0:
+				break;
+			default:
+				continue;
+		}
+		i++; // warning 225: unreachable code
+	}
+	return i;
+}
+
+test_switch_3()
+{
+	switch (g_var)
+	{
+		case 0:
+			return 0;
+		case 1:
+			return 1;
+	}
+	// shouldn't cause warning 225 ("unreachable code")
+	return 2;
+}
+
 main()
 {
 	test_if_1();
 	test_if_2();
+	test_switch_1();
+	test_switch_2();
+	test_switch_3();
 }

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -104,6 +104,33 @@ test_endless()
 	// shouldn't cause warning 209 ("function should return a value")
 }
 
+test_goto_1()
+{
+label_1:
+	goto label_1;
+	return 0; // warning 225: unreachable code
+}
+
+test_goto_2()
+{
+	if (g_var == 0)
+		goto label_2;
+label_1:
+	goto label_1;
+label_2:
+	// shouldn't cause warning 225 ("unreachable code")
+	return 1;
+}
+
+test_goto_3()
+{
+	if (g_var != 0)
+		return 1;
+label_1:
+	goto label_1;
+	// shouldn't cause warning 209 ("function should return a value")
+}
+
 main()
 {
 	test_if_1();
@@ -115,4 +142,7 @@ main()
 	test_switch_2();
 	test_switch_3();
 	test_endless();
+	test_goto_1();
+	test_goto_2();
+	test_goto_3();
 }

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -1,0 +1,32 @@
+#include <core>
+#include <console>
+
+new g_var = 0;
+
+test_if_1()
+{
+	if (g_var != 0)
+		return 0;
+	else
+		return 1;
+	return 2; // warning 225: unreachable code
+}
+
+test_if_2()
+{
+	new i = 0;
+	while (i < 10)
+	{
+		if (g_var != 0)
+			return;
+		else
+			continue;
+		i++; // warning 225: unreachable code
+	}
+}
+
+main()
+{
+	test_if_1();
+	test_if_2();
+}

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -54,16 +54,17 @@ test_if_5()
 
 test_switch_1()
 {
+	new var0 = 0, var1 = 1, var2 = 2, var3 = 3;
 	switch (g_var)
 	{
 		case 0:
-			return 0;
+			return var0;
 		case 1:
-			return 1;
+			return var1;
 		default:
-			return 2;
+			return var2;
 	}
-	return 3; // warning 225: unreachable code
+	return var3; // warning 225: unreachable code
 }
 
 test_switch_2()
@@ -94,6 +95,21 @@ test_switch_3()
 	}
 	// shouldn't cause warning 225 ("unreachable code")
 	return 2;
+}
+
+test_switch_4()
+{
+	switch (g_var)
+	{
+		case 0:
+			return 0;
+		case 1:
+			return 1;
+		default:
+			return 2;
+	}
+	// shouldn't cause warning 225 ("unreachable code")
+	return 3;
 }
 
 test_endless()
@@ -155,6 +171,7 @@ main()
 	test_switch_1();
 	test_switch_2();
 	test_switch_3();
+	test_switch_4();
 	test_endless();
 	test_goto_1();
 	test_goto_2();

--- a/source/compiler/tests/unreachable_code.pwn
+++ b/source/compiler/tests/unreachable_code.pwn
@@ -161,6 +161,12 @@ label_1:
 	return 2;
 }
 
+test_exit()
+{
+	exit 0;
+	return 0; // warning 225: unreachable code
+}
+
 main()
 {
 	test_if_1();
@@ -177,4 +183,5 @@ main()
 	test_goto_2();
 	test_goto_3();
 	test_goto_4();
+	test_exit();
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes various bugs as well as adds new functionality for more accurate detection of unreachable code (warning 225):
* Fixes code being falsely reported as unreachable when the `true` branch of a preceding `if` statement ends with `return`, `break`, `continue` or an endless loop, and the `false` branch is empty (#555).
* Fixes unreachable code not being detected when the two `if` branches end with different kinds of terminal statements (#556).
  (By "terminal statements" I mean `return`, `break`, `continue` or an endless loop - is that a correct term for them? If not, please feel free to correct me.)
* Fixes labels being falsely detected as unreachable code, when a label is used via `goto` and then defined after an `if` statement that has both branches ending with `return` (#565).
* Adds detection of unreachable code after `goto`, `switch` and `exit` statements (#559, #560, #566).

**Which issue(s) this PR fixes**:

Fixes #555, #556, #559, #560, #565, #566

**What kind of pull this is**:

* [x] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: