### PR TITLE
Fix false-positive warning 240 messages

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3208,7 +3208,7 @@ SC_FUNC void markinitialized(symbol *sym,int assignment)
     return;
   if (sc_status==statFIRST && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
     return;
-  if (assignment && sym->vclass!=sGLOBAL && (sym->ident==iVARIABLE || sym->ident==iREFERENCE)) {
+  if (assignment && sym->vclass==sLOCAL && (sym->ident==iVARIABLE || sym->ident==iREFERENCE)) {
     sym->usage |= uASSIGNED;
     sym->assignlevel=pc_nestlevel;
   } /* if */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1083,8 +1083,7 @@ static int hier14(value *lval1)
   if (oper==NULL) {
     symbol *sym=lval3.sym;
     assert(sym!=NULL);
-    if ((sym->usage & uASSIGNED)!=0 && sym->assignlevel>=pc_nestlevel
-        && (sym->vclass==sLOCAL || sym->vclass==sSTATIC))
+    if ((sym->usage & uASSIGNED)!=0 && sym->assignlevel>=pc_nestlevel && sym->vclass==sLOCAL)
       error(240,sym->name); /* previously assigned value is unused */
     markinitialized(sym,TRUE);
     if (pc_ovlassignment)

--- a/source/compiler/tests/warning_240.meta
+++ b/source/compiler/tests/warning_240.meta
@@ -12,7 +12,6 @@ warning_240.pwn(97) : warning 240: previously assigned value is never used (symb
 warning_240.pwn(109) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(120) : warning 240: previously assigned value is never used (symbol "local_var")
 warning_240.pwn(139) : warning 240: previously assigned value is never used (symbol "local_var")
-warning_240.pwn(148) : warning 240: previously assigned value is never used (symbol "local_static_var")
 warning_240.pwn(174) : warning 240: previously assigned value is never used (symbol "arg")
 warning_240.pwn(178) : warning 240: previously assigned value is never used (symbol "arg")
 warning_240.pwn(183) : warning 240: previously assigned value is never used (symbol "refarg")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes false-positive `warning 240: previously assigned value is never used` messages printed for local variables in (rather rare) cases when a function first assigns a value to a static variable, then calls itself recursively and uses the assigned value in the nested call.
Example:
```Pawn
RecursiveFunc()
{
    static n = 0;
    if (n == 0) // assignment "n = 1" is used here in a nested call
    {
        n = 1;
        RecursiveFunc();
        n = 0; // warning 240: previously assigned value is never used (symbol "n")
    }
}
```
There's no way to analyze such complicated uses of static local variables accurately because the compiler works in a linear way, so as a solution I disabled tracking of unused assigned values for static variables completely.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: