### PR TITLE
Implement `__timestamp`

### DIFF
--- a/source/compiler/CMakeLists.txt
+++ b/source/compiler/CMakeLists.txt
@@ -176,6 +176,7 @@ if(BUILD_TESTING)
     ../amx/amxaux.h
     ../amx/amxcons.c
     ../amx/amxcore.c
+    ../amx/amxstring.c
   )
   if(UNIX)
     set(PAWNRUNS_SRCS

--- a/source/compiler/pawnruns.c
+++ b/source/compiler/pawnruns.c
@@ -27,6 +27,7 @@ static void PrintUsage(char *program)
 int main(int argc,char *argv[])
 {
   extern AMX_NATIVE_INFO console_Natives[];
+  extern AMX_NATIVE_INFO string_Natives[];
   extern AMX_NATIVE_INFO core_Natives[];
 
   AMX amx;
@@ -41,6 +42,7 @@ int main(int argc,char *argv[])
     ErrorExit(&amx, err);
 
   amx_Register(&amx, console_Natives, -1);
+  amx_Register(&amx, string_Natives, -1);
   err = amx_Register(&amx, core_Natives, -1);
   if (err != AMX_ERR_NONE)
     ErrorExit(&amx, err);

--- a/source/compiler/tests/__timestamp.meta
+++ b/source/compiler/tests/__timestamp.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'runtime',
+  'output': """
+result: 0
+__timestamp.amx returns 0
+  """,
+  'should_fail': False
+}

--- a/source/compiler/tests/__timestamp.pwn
+++ b/source/compiler/tests/__timestamp.pwn
@@ -1,0 +1,13 @@
+#include <console>
+#include <string>
+
+main()
+{
+	new day_seconds = __timestamp % (60 * 60 * 24);
+	new hour = day_seconds / (60 * 60);
+	new minute = (day_seconds % (60 * 60)) / 60;
+	new second = day_seconds % 60;
+	new buf[9];
+	strformat(buf, _, _, "%02d:%02d:%02d", hour, minute, second);
+	printf("result: %d\n", strcmp(buf, __time));
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does the following:
* Implements new built-in constant `__timestamp` (see #591).
* Adds the `amxString` extension module into the test script runner (`pawnruns`) as a built-in module.
  I did this in order to be able to use functions `strformat()` and `strcmp()`, to convert the value in `__timestamp` into a string and compare the result with `__time`.

**Which issue(s) this PR fixes**:

Fixes #591

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: