### PR TITLE
Properly parse array indices when the array symbol is invalid

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1741,22 +1741,27 @@ restart:
       return FALSE;
     } /* if */
     if (tok=='[' || tok=='{') { /* subscript */
+      int invsubscript=FALSE;
       close = (char)((tok=='[') ? ']' : '}');
       if (sym==NULL) {  /* sym==NULL if lval is a constant or a literal */
         error(28,"<no variable>");  /* cannot subscript */
-        needtoken(close);
-        return FALSE;
-      } else if (sym->ident!=iARRAY && sym->ident!=iREFARRAY){
+        invsubscript=TRUE;
+      } else if (sym->ident!=iARRAY && sym->ident!=iREFARRAY) {
         error_suggest(28,sym->name,NULL,estSYMBOL,esfARRAY);/* cannot subscript, variable is not an array */
-        needtoken(close);
-        return FALSE;
+        invsubscript=TRUE;
       } else if (sym->dim.array.level>0 && close!=']') {
         error(51);      /* invalid subscript, must use [ ] */
-        needtoken(close);
-        return FALSE;
+        invsubscript=TRUE;
       } /* if */
-      /* set the tag to match (enumeration fields as indices) */
-      lval2.cmptag=sym->x.tags.index;
+      if (invsubscript) {
+        if (sym!=NULL && sym->ident!=iFUNCTN)
+          sym->usage |= uREAD;  /* avoid the "symbol is never used" warning */
+        if (matchtoken(close))
+          return FALSE;         /* return if there's no index sub-expression */
+      } else {
+        /* set the tag to match (enumeration fields as indices) */
+        lval2.cmptag=sym->x.tags.index;
+      } /* if */
       stgget(&index,&cidx);     /* mark position in code generator */
       pushreg(sPRI);            /* save base address of the array */
       if (hier14(&lval2))       /* create expression for the array index */
@@ -1764,6 +1769,18 @@ restart:
       if (lval2.ident==iARRAY || lval2.ident==iREFARRAY)
         error(33,lval2.sym->name);      /* array must be indexed */
       needtoken(close);
+      if (invsubscript) {
+        /* parse the next index if this is not the lowest array dimension */
+        if (sym!=NULL && (sym->ident==iARRAY || sym->ident==iREFARRAY) && sym->dim.array.level>0) {
+          lval1->ident=iREFARRAY;
+          lval1->sym=finddepend(sym);
+          assert(lval1->sym!=NULL);
+          assert(lval1->sym->dim.array.level==sym->dim.array.level-1);
+          cursym=lval1->sym;
+          goto restart;
+        } /* if */
+        return FALSE;
+      } /* if */
       check_tagmismatch(sym->x.tags.index,lval2.tag,TRUE,-1);
       if (lval2.ident==iCONSTEXPR) {    /* constant expression */
         stgdel(index,cidx);             /* scratch generated code */

--- a/source/compiler/tests/gh_594.meta
+++ b/source/compiler/tests/gh_594.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_594.pwn(11) : error 017: undefined symbol "undefined"
+gh_594.pwn(14) : error 028: invalid subscript (not an array or too many subscripts): "var"
+gh_594.pwn(17) : error 051: invalid subscript, use "[ ]" operators on major dimensions
+  """
+}

--- a/source/compiler/tests/gh_594.pwn
+++ b/source/compiler/tests/gh_594.pwn
@@ -1,0 +1,20 @@
+main()
+{
+	new var = 0;
+	static const arr[1][1];
+	switch (var)
+	{
+		// Case 1: Array symbol is undefined.
+		// NOTE: The "invalid subscript" error doesn't get printed (although the
+		// compiler attempts to print it) because the "undefined symbol" error is
+		// printed first and error printing is limited to 1 error per statement.
+		case 1: return undefined[0]; // error 017: undefined symbol "undefined"
+		
+		// Case 2: Symbol is not an array.
+		case 2: return var[0]; // error 028: invalid subscript (not an array or too many subscripts): "var"
+
+		// Case 3: Curly brackets can only be used on the lowest dimension.
+		case 3: return arr{0}[0]; // error 051: invalid subscript, use "[ ]" operators on major dimensions
+	}
+	return 0;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the compiler properly parse array index sub-expression when the array symbol is invalid (undefined or not an array), and when curly brackets are used on one of the major array dimensions, thus fixing invalid error and warning messages (see #594).

Example:
```Pawn
main()
{
	new var = 0;
	return var[0]; // line 4
}
```
Output before this PR:
```
test.pwn(4) : error 028: invalid subscript (not an array or too many subscripts): "var"
test.pwn(4) : warning 215: expression has no effect
test.pwn(4) : error 001: expected token: ";", but found "]"
test.pwn(4) : error 029: invalid expression, assumed zero
test.pwn(4) : fatal error 107: too many error messages on one line
```
After:
```
test.pwn(4) : error 028: invalid subscript (not an array or too many subscripts): "var"
```

**Which issue(s) this PR fixes**:

Fixes #594

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
