### PR TITLE
Fix redefinition of enum elements

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2850,9 +2850,8 @@ static void symbol_cache_add(symbol *sym)
     return;
   } /* if */
   cache_sym=*pcache_sym;
-  while (cache_sym->htnext!=NULL)
-    cache_sym=cache_sym->htnext;
-  cache_sym->htnext=sym;
+  *pcache_sym=sym;
+  sym->htnext=cache_sym;
 }
 
 static void symbol_cache_remove(symbol *sym)

--- a/source/compiler/tests/gh_597.meta
+++ b/source/compiler/tests/gh_597.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_597.pwn(5) : error 021: symbol already defined: "e0"
+  """
+}

--- a/source/compiler/tests/gh_597.pwn
+++ b/source/compiler/tests/gh_597.pwn
@@ -1,0 +1,9 @@
+enum Enum0 { e0, e1 };
+enum Enum1
+{
+	e0,
+	e0, // error 021: symbol already defined: "e0"
+	e1
+};
+
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes function `symbol_cache_add()` add symbols with the same name into the head of the entry list. This allows `find_symbol()` to pick the last defined symbol when there are multiple symbols with the same name, thus returning it the old behavior it had before the adoption of the hashtable-based symbol search algorithm, and fixing a problem with `findglb()` returning wrong symbols when being called from `add_constant()` (see #597).

**Which issue(s) this PR fixes**:

Fixes #597

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: