### PR TITLE
Parse case values when the case is not in switch

### DIFF
--- a/source/compiler/tests/gh_574.meta
+++ b/source/compiler/tests/gh_574.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_574.pwn(5) : error 014: invalid statement; not in switch
+gh_574.pwn(6) : error 014: invalid statement; not in switch
+  """
+}

--- a/source/compiler/tests/gh_574.pwn
+++ b/source/compiler/tests/gh_574.pwn
@@ -1,0 +1,12 @@
+enum { test, test2 };
+
+main()
+{
+	default:{}
+	case test, test2:
+	{
+		return Func();
+	}
+}
+
+Func() return 1;


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the compiler parse the case values and the ending `:`in erroneous situations when there's a case outside of switch.
This fixes the problem described in #574.

**Which issue(s) this PR fixes**:

Fixes #574

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: