### PR TITLE
Fix invalid code generation for comma-separated expressions

### DIFF
--- a/source/compiler/tests/gh_96.meta
+++ b/source/compiler/tests/gh_96.meta
@@ -1,0 +1,25 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  nop
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  switch [0-9a-f]+
+[0-9a-f]+  push.c 00000000
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  zero.pri
+[0-9a-f]+  stor.pri 00000004
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  load.pri 00000000
+[0-9a-f]+  inc 00000000
+[0-9a-f]+  zero.pri
+[0-9a-f]+  stor.pri 00000004
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  zero.pri
+[0-9a-f]+  stor.pri 00000004
+[0-9a-f]+  jump [0-9a-f]+
+[0-9a-f]+  casetbl 00000002 [0-9a-f]+
+                  00000000 [0-9a-f]+
+                  00000001 [0-9a-f]+
+[0-9a-f]+  nop
+"""
+}

--- a/source/compiler/tests/gh_96.pwn
+++ b/source/compiler/tests/gh_96.pwn
@@ -1,0 +1,24 @@
+#pragma option -O0 // disable optimizations
+
+Func() return 1;
+
+main()
+{
+	static x = 0, y;
+
+	__emit nop;
+	switch (x)
+	{
+		// The code for "Func()" call shouldn't be erased.
+		case 0:  y = (Func(), 0);
+
+		// The code for the increment shouldn't be erased.
+		case 1:  y = (x++, 0);
+
+		// The "1 + 2" part is constant, so its code can be safely discarded.
+		default: y = (1 + 2, 0);
+	}
+	__emit nop;
+
+	return y;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the bug with incorrect code generation for comma-separated expressions, when the code for the whole expression gets erased if the last comma-separated sub-expression has a constant result (see https://github.com/pawn-lang/compiler/issues/96#issuecomment-403371141).

**Which issue(s) this PR fixes**:

Fixes #96

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: