### PR TITLE
Fix invalid error/warning messages when `stock` is used in a local variable declaration

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5510,6 +5510,9 @@ static void statement(int *lastindent,int allow_decl)
   case 0:
     /* nothing */
     break;
+  case tSTOCK:
+    error(10);                  /* invalid function or declaration */
+    /* fallthrough */
   case tNEW:
     if (allow_decl) {
       declloc(FALSE);

--- a/source/compiler/tests/gh_603.meta
+++ b/source/compiler/tests/gh_603.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_603.pwn(3) : error 010: invalid function or declaration
+gh_603.pwn(3) : warning 204: symbol is assigned a value that is never used: "n"
+  """
+}

--- a/source/compiler/tests/gh_603.pwn
+++ b/source/compiler/tests/gh_603.pwn
@@ -1,0 +1,4 @@
+main()
+{
+	stock n = 0; // error 010: invalid function or declaration
+}                // warning 204: symbol is assigned a value that is never used: "n"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes invalid/ambiguous error/warning messages when keyword `stock` is used in a local variable declaration (see #603) by making the compiler use more descriptive "`error 010: invalid function or declaration`" and continue parsing the declaration as if it was started with keyword `new`, to avoid further invalid errors and warnings.

**Which issue(s) this PR fixes**:

Fixes #603

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
