### PR TITLE
Fix warning 244

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -6067,7 +6067,7 @@ static void doswitch(void)
   int swdefault,casecount;
   int tok,endtok;
   int swtag,csetag;
-  int enumsymcount,diff;
+  int enumsymcount;
   int save_fline;
   symbol *enumsym,*csesym;
   int ident;
@@ -6215,7 +6215,7 @@ static void doswitch(void)
   } while (tok!=endtok);
   restoreassignments(pc_nestlevel+1,assignments);
 
-  if (enumsym!=NULL && swdefault==FALSE && (diff=enumsym->x.tags.unique-enumsymcount)<=2) {
+  if (enumsym!=NULL && swdefault==FALSE && enumsym->x.tags.unique-enumsymcount<=2) {
     constvalue_root *enumlist=enumsym->dim.enumlist;
     constvalue *val,*prev=NULL,*save_next=NULL;
     for (val=enumlist->first; val!=NULL; prev=val,val=val->next) {

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -6233,8 +6233,9 @@ static void doswitch(void)
       /* check if the value of this constant is handled in switch, if so - continue */
       if (find_constval_byval(&caselist,val->value)!=NULL)
         continue;
+      errorset(sSETPOS,save_fline);
       error(244,val->name); /* enum element not handled in switch */
-      /*  */
+      errorset(sSETPOS,-1);
     } /* while */
   } /* if */
 

--- a/source/compiler/tests/warning_244.meta
+++ b/source/compiler/tests/warning_244.meta
@@ -1,7 +1,7 @@
 {
   'test_type': 'output_check',
   'errors': """
-warning_244.pwn(37) : warning 244: enum element "CONST2_3" not handled in switch
-warning_244.pwn(37) : warning 244: enum element "CONST2_5" not handled in switch
+warning_244.pwn(30) : warning 244: enum element "CONST2_3" not handled in switch
+warning_244.pwn(30) : warning 244: enum element "CONST2_5" not handled in switch
 """
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the compiler print warning 244 ("`enum element not handled in switch`") at the line where the `switch` statement starts, instead of where it ends.
This is how I initially intended to implement this warning, as previously I introduced variable `save_fline` in function `do_switch()`, but I forgot to use it via `errorset()` when displaying the warning. This PR fixes that mistake.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
