### PR TITLE
Fixes for `#pragma warning`

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -841,6 +841,8 @@ SC_FUNC void outinstr(const char *name,emit_outval params[],int numparams);
 /* function prototypes in SC5.C */
 SC_FUNC int error(long number,...);
 SC_FUNC void errorset(int code,int line);
+SC_FUNC void warnstack_init(void);
+SC_FUNC void warnstack_cleanup(void);
 SC_FUNC int error_suggest(int number,const char *name,const char *name2,int type,int subtype);
 
 /* function prototypes in SC6.C */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -615,8 +615,8 @@ int pc_compile(int argc, char **argv);
 int pc_addconstant(char *name,cell value,int tag);
 int pc_addtag(char *name);
 int pc_enablewarning(int number,warnmode enable);
-int pc_pushwarnings(void);
-int pc_popwarnings(void);
+void pc_pushwarnings(void);
+void pc_popwarnings(void);
 void pc_seterrorwarnings(int enable);
 int pc_geterrorwarnings(void);
 

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -613,8 +613,10 @@ int pc_compile(int argc, char *argv[])
           error(100,incfname);          /* cannot read from ... (fatal error) */
       } /* if */
     } /* if */
+    warnstack_init();
     preprocess();                       /* fetch first line */
     parse();                            /* process all input */
+    warnstack_cleanup();
     sc_parsenum++;
   } while (sc_reparse);
 
@@ -700,8 +702,10 @@ int pc_compile(int argc, char *argv[])
     else
       plungequalifiedfile(incfname);    /* parse implicit include file (again) */
   } /* if */
+  warnstack_init();
   preprocess();                         /* fetch first line */
   parse();                              /* process all input */
+  warnstack_cleanup();
   if (sc_listing)
     goto cleanup;
   /* inpf is already closed when readline() attempts to pop of a file */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -980,6 +980,7 @@ void parsesingleoption(char *argv);
 
 static int command(void)
 {
+  static const char str_if[]="#if...";
   int tok,ret;
   cell val;
   char *str;
@@ -1024,7 +1025,7 @@ static int command(void)
     ret=CMD_IF;
     assert(iflevel>=0);
     if (iflevel==0) {
-      error(26);                /* no matching #if */
+      error(26,str_if);         /* no matching #if */
       errorset(sRESET,0);
     } else {
       /* check for earlier #else */
@@ -1077,7 +1078,7 @@ static int command(void)
   case tpENDIF:
     ret=CMD_IF;
     if (iflevel==0){
-      error(26);        /* no matching "#if" */
+      error(26,str_if);         /* no matching "#if" */
       errorset(sRESET,0);
     } else {
       clearassignments(1);

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1308,9 +1308,10 @@ static int command(void)
           if (ok) {
             if (strcmp(str,"enable")==0 || strcmp(str,"disable")==0) {
               cell val;
+              enum s_warnmode enable=(str[0]=='e') ? warnENABLE : warnDISABLE;
               do {
                 preproc_expr(&val,NULL);
-                pc_enablewarning(val,(str[0]=='e') ? warnENABLE : warnDISABLE);
+                pc_enablewarning(val,enable);
               } while (*lptr!='\0');
             } else if (strcmp(str,"push")==0) {
               pc_pushwarnings();

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -65,7 +65,7 @@ static char *errmsg[] = {
 /*023*/  "array assignment must be simple assignment\n",
 /*024*/  "\"break\" or \"continue\" is out of context\n",
 /*025*/  "function heading differs from prototype\n",
-/*026*/  "no matching \"#if...\"\n",
+/*026*/  "no matching \"%s\"\n",
 /*027*/  "invalid character constant\n",
 /*028*/  "invalid subscript (not an array or too many subscripts): \"%s\"\n",
 /*029*/  "invalid expression, assumed zero\n",
@@ -437,8 +437,10 @@ void pc_pushwarnings(void)
 void pc_popwarnings(void)
 {
   void *p;
-  if (warnstack.next==NULL)
-    return;     /* nothing to do */
+  if (warnstack.next==NULL) {
+    error(26,"#pragma warning push");   /* no matching "#pragma warning push" */
+    return;                             /* nothing to do */
+  } /* if */
   p=warnstack.next;
   memmove(&warnstack,p,sizeof(struct s_warnstack));
   free(p);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -454,6 +454,8 @@ SC_FUNC void warnstack_init(void)
 SC_FUNC void warnstack_cleanup(void)
 {
   struct s_warnstack *cur,*next;
+  if (warnstack.next!=NULL)
+    error(1,"#pragma warning pop","-end of file-");
   for (cur=warnstack.next; cur!=NULL; cur=next) {
     next=cur->next;
     free(cur);

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -446,6 +446,21 @@ void pc_popwarnings(void)
   free(p);
 }
 
+SC_FUNC void warnstack_init(void)
+{
+  memset(&warnstack,0,sizeof(warnstack));
+}
+
+SC_FUNC void warnstack_cleanup(void)
+{
+  struct s_warnstack *cur,*next;
+  for (cur=warnstack.next; cur!=NULL; cur=next) {
+    next=cur->next;
+    free(cur);
+  } /* for */
+  warnstack.next=NULL;
+}
+
 /* pc_seterrorwarnings()
  * Make warnings errors (or not).
  */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -421,31 +421,27 @@ int pc_enablewarning(int number,warnmode enable)
 /* pc_pushwarnings()
  * Saves currently disabled warnings, used to implement #pragma warning push
  */
-int pc_pushwarnings(void)
+void pc_pushwarnings(void)
 {
   void *p;
   p=calloc(sizeof(struct s_warnstack),1);
-  if (p==NULL) {
+  if (p==NULL)
     error(103); /* insufficient memory */
-    return FALSE;
-  }
   memmove(p,&warnstack,sizeof(struct s_warnstack));
   warnstack.next=p;
-  return TRUE;
 }
 
 /* pc_popwarnings()
  * This function is the reverse of pc_pushwarnings()
  */
-int pc_popwarnings(void)
+void pc_popwarnings(void)
 {
   void *p;
   if (warnstack.next==NULL)
-    return FALSE; /* nothing to do */
+    return;     /* nothing to do */
   p=warnstack.next;
   memmove(&warnstack,p,sizeof(struct s_warnstack));
   free(p);
-  return TRUE;
 }
 
 /* pc_seterrorwarnings()

--- a/source/compiler/tests/pragma_warning_1.meta
+++ b/source/compiler/tests/pragma_warning_1.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+pragma_warning_1.pwn(1) : warning 238: meaningless combination of class specifiers (const reference)
+pragma_warning_1.pwn(8) : warning 238: meaningless combination of class specifiers (const reference)
+"""
+}

--- a/source/compiler/tests/pragma_warning_1.pwn
+++ b/source/compiler/tests/pragma_warning_1.pwn
@@ -1,0 +1,13 @@
+forward Func(const &arg); // warning 238: meaningless combination of class specifiers (const reference)
+
+#pragma warning disable 238
+#pragma warning push
+forward Func(const &arg); // shouldn't warn on this line
+
+#pragma warning enable 238
+forward Func(const &arg); // warning 238: meaningless combination of class specifiers (const reference)
+
+#pragma warning pop
+forward Func(const &arg); // shouldn't warn on this line
+
+main(){}

--- a/source/compiler/tests/pragma_warning_2.meta
+++ b/source/compiler/tests/pragma_warning_2.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+pragma_warning_2.pwn(5) : error 001: expected token: "#pragma warning pop", but found "-end of file-"
+"""
+}

--- a/source/compiler/tests/pragma_warning_2.pwn
+++ b/source/compiler/tests/pragma_warning_2.pwn
@@ -1,0 +1,4 @@
+#pragma warning disable 238
+#pragma warning push
+main(){}
+// error 001: expected token: "#pragma warning pop", but found "-end of file-"

--- a/source/compiler/tests/pragma_warning_3.meta
+++ b/source/compiler/tests/pragma_warning_3.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+pragma_warning_3.pwn(1) : error 026: no matching "#pragma warning push"
+"""
+}

--- a/source/compiler/tests/pragma_warning_3.pwn
+++ b/source/compiler/tests/pragma_warning_3.pwn
@@ -1,0 +1,2 @@
+#pragma warning pop // error 026: no matching "#pragma warning push"
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes `#pragma warning disable` not being reset at the end of each compilation pass, resulting in its effects being carried onto the subsequent compilation passes (see #610).
* Makes the compiler issue an error when `#pragma warning push` is used more times than `#pragma warning pop` and vice versa (see #610).
* Changes the return value type of `pc_pushwarnings()` and `pc_popwarnings()` from `int` to `void`.
  `pc_pushwarnings()` never returns `FALSE`; in case of memory allocation failure it calls `error(103)`, which aborts execution (as 103 is a fatal error), making the line `return FALSE;` unreachable.
  Also, the values returned by both `pc_pushwarnings()` and `pc_popwarnings()` are never used.
* Covers `#pragma warning push/pop/enable/disable` with tests (previously there weren't any).

**Which issue(s) this PR fixes**:

Fixes #610

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

