### PR TITLE
 Check if the entry function is actually defined, not only declared

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5123,7 +5123,8 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
         if (!strempty(symname))
           error(203,symname);       /* symbol isn't used ... (and not public/native/stock) */
       } /* if */
-      if ((sym->usage & uPUBLIC)!=0 || strcmp(sym->name,uMAINFUNC)==0)
+      if (((sym->usage & uPUBLIC)!=0 || strcmp(sym->name,uMAINFUNC)==0)
+          && (sym->usage & uDEFINE)!=0)
         entry=TRUE;                 /* there is an entry point */
       /* also mark the function to the debug information */
       if (((sym->usage & uREAD)!=0 || (sym->usage & uPUBLIC)!=0) && (sym->usage & uNATIVE)==0)

--- a/source/compiler/tests/error_013_1.meta
+++ b/source/compiler/tests/error_013_1.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+  """
+}

--- a/source/compiler/tests/error_013_1.pwn
+++ b/source/compiler/tests/error_013_1.pwn
@@ -1,0 +1,2 @@
+forward main();
+main(){}

--- a/source/compiler/tests/error_013_2.meta
+++ b/source/compiler/tests/error_013_2.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+  """
+}

--- a/source/compiler/tests/error_013_2.pwn
+++ b/source/compiler/tests/error_013_2.pwn
@@ -1,0 +1,2 @@
+forward public Func();
+public Func(){}

--- a/source/compiler/tests/error_013_3.meta
+++ b/source/compiler/tests/error_013_3.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+error_013_3.pwn(2) : error 013: no entry point (no public functions)
+  """
+}

--- a/source/compiler/tests/error_013_3.pwn
+++ b/source/compiler/tests/error_013_3.pwn
@@ -1,0 +1,1 @@
+forward main();

--- a/source/compiler/tests/error_013_4.meta
+++ b/source/compiler/tests/error_013_4.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+error_013_4.pwn(2) : error 013: no entry point (no public functions)
+  """
+}

--- a/source/compiler/tests/error_013_4.pwn
+++ b/source/compiler/tests/error_013_4.pwn
@@ -1,0 +1,1 @@
+forward public Func();

--- a/source/compiler/tests/multiline_string_sizes.pwn
+++ b/source/compiler/tests/multiline_string_sizes.pwn
@@ -21,3 +21,4 @@ new str5[] = "hello
 
 #pragma unused str1, str2, str3, str4, str5
 
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the compiler not aborting compilation when the entry function is declared, but not defined (see #629).

**Which issue(s) this PR fixes**:

Fixes #629

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: