### PR TITLE
Ignore state specifications in old-style function declarations

### DIFF
--- a/source/compiler/tests/warning_231.meta
+++ b/source/compiler/tests/warning_231.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+warning_231.pwn(3) : warning 231: state specification on forward declaration is ignored
+warning_231.pwn(6) : warning 231: state specification on forward declaration is ignored
+"""
+}

--- a/source/compiler/tests/warning_231.pwn
+++ b/source/compiler/tests/warning_231.pwn
@@ -1,0 +1,9 @@
+#pragma option -;+
+
+forward Func() <auto1:st1>; // warning 231: state specification on forward declaration is ignored
+public Func() <auto1:st1> {}
+
+public Func() <auto1:st2>; // warning 231: state specification on forward declaration is ignored
+public Func() <auto1:st2> {}
+
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the compiler print warning 231 (`state specification on forward declaration is ignored`) for state specifications used in old-style function declarations (see #632).

**Which issue(s) this PR fixes**:

Fixes #632

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: