### PR TITLE
Fix assertion failure when printing warning 203

### DIFF
--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -246,7 +246,7 @@ static short lastfile;
   char *msg,*pre;
   va_list argptr;
   char string[128];
-  int notice;
+  int notice,start;
 
   /* split the error field between the real error/warning number and an optional
    * "notice" number
@@ -303,15 +303,15 @@ static short lastfile;
   } /* if */
 
   assert(errstart<=fline);
+  start=errstart;
   if (errline>0)
-    errstart=errline;
+    start=errline;
   else
     errline=fline;
-  assert(errstart<=errline);
+  assert(start<=errline);
   va_start(argptr,number);
   if (errfname[0]=='\0') {
-    int start=(errstart==errline) ? -1 : errstart;
-    if (pc_error((int)number,msg,inpfname,start,errline,argptr)) {
+    if (pc_error((int)number,msg,inpfname,((start==errline) ? -1 : start),errline,argptr)) {
       if (outf!=NULL) {
         pc_closeasm(outf,TRUE);
         outf=NULL;
@@ -321,8 +321,8 @@ static short lastfile;
   } else {
     FILE *fp=fopen(errfname,"a");
     if (fp!=NULL) {
-      if (errstart>=0 && errstart!=errline)
-        fprintf(fp,"%s(%d -- %d) : %s %03d: ",inpfname,errstart,errline,pre,(int)number);
+      if (start>=0 && start!=errline)
+        fprintf(fp,"%s(%d -- %d) : %s %03d: ",inpfname,start,errline,pre,(int)number);
       else
         fprintf(fp,"%s(%d) : %s %03d: ",inpfname,errline,pre,(int)number);
       vfprintf(fp,msg,argptr);
@@ -346,7 +346,7 @@ static short lastfile;
 
   errline=-1;
   /* check whether we are seeing many errors on the same line */
-  if ((errstart<0 && lastline!=fline) || lastline<errstart || lastline>fline || fcurrent!=lastfile)
+  if ((start<0 && lastline!=fline) || lastline<start || lastline>fline || fcurrent!=lastfile)
     errorcount=0;
   lastline=fline;
   lastfile=fcurrent;

--- a/source/compiler/tests/__pragma.meta
+++ b/source/compiler/tests/__pragma.meta
@@ -14,6 +14,6 @@ __pragma.pwn(67) : warning 207: unknown #pragma
 __pragma.pwn(68) : warning 207: unknown #pragma
 __pragma.pwn(33) : warning 203: symbol is never used: "f"
 __pragma.pwn(29) : warning 204: symbol is assigned a value that is never used: "e"
-__pragma.pwn(29 -- 70) : warning 203: symbol is never used: "operator~(Tag:)"
+__pragma.pwn(70) : warning 203: symbol is never used: "operator~(Tag:)"
 """
 }

--- a/source/compiler/tests/gh_398.inc
+++ b/source/compiler/tests/gh_398.inc
@@ -1,0 +1,4 @@
+/* 3 empty lines */
+
+
+new a, b;// <= line 4

--- a/source/compiler/tests/gh_398.meta
+++ b/source/compiler/tests/gh_398.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_398.pwn(4) : warning 203: symbol is never used: "a"
+gh_398.pwn(4) : warning 203: symbol is never used: "b"
+  """
+}

--- a/source/compiler/tests/gh_398.pwn
+++ b/source/compiler/tests/gh_398.pwn
@@ -1,0 +1,2 @@
+#include "gh_398.inc"
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes assertion failure "errstart<=fline" when displaying `warning 203: symbol is never used` (see https://github.com/pawn-lang/compiler/issues/398#issuecomment-791512488 for the explanation).

**Which issue(s) this PR fixes**:

Fixes #398 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

