### PR TITLE
Fix typos discovered with codespell

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -466,7 +466,7 @@ enum {
   teFUNCTN, /* Pawn function */
   teNATIVE, /* native function */
   teNONNEG, /* nonnegative integer */
-  /* for assigment to "lastst" only (see SC1.C) */
+  /* for assignment to "lastst" only (see SC1.C) */
   tEXPR,
   tENDLESS, /* endless loop */
   tTERMINAL, /* signalizes that the code after this statement is unreachable,

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1550,7 +1550,7 @@ static void usage(void)
     pc_printf("         -\\       use '\\' for escape characters\n");
     pc_printf("         -^       use '^' for escape characters\n");
     pc_printf("         -;[+/-]  require a semicolon to end each statement (default=%c)\n", sc_needsemicolon ? '+' : '-');
-    pc_printf("         -([+/-]  require parantheses for function invocation (default=%c)\n", optproccall ? '-' : '+');
+    pc_printf("         -([+/-]  require parentheses for function invocation (default=%c)\n", optproccall ? '-' : '+');
     pc_printf("         sym=val  define constant \"sym\" with value \"val\"\n");
     pc_printf("         sym=     define constant \"sym\" with value 0\n");
 #if defined	__WIN32__ || defined _WIN32 || defined _Windows || defined __MSDOS__
@@ -1750,7 +1750,7 @@ static void parse(void)
       } else {
         /* This can be a static function or a static global variable; we know
          * which of the two as soon as we have parsed up to the point where an
-         * opening paranthesis of a function would be expected. To back out after
+         * opening parenthesis of a function would be expected. To back out after
          * deciding it was a declaration of a static variable after all, we have
          * to store the symbol name and tag.
          */
@@ -2287,7 +2287,7 @@ static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,int fst
       sym->fnumber=filenum;
     if (explicit_init)
       markinitialized(sym,TRUE);
-    sc_attachdocumentation(sym);/* attach any documenation to the variable */
+    sc_attachdocumentation(sym);/* attach any documentation to the variable */
     if (sc_status==statSKIP) {
       sc_status=statWRITE;
       code_idx=cidx;
@@ -2675,7 +2675,7 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
         if (d==dim[numdim-2])
           dim[numdim-1]=match;
       } /* if */
-      /* after all arrays have been initalized, we know the (major) dimensions
+      /* after all arrays have been initialized, we know the (major) dimensions
        * of the array and we can properly adjust the indirection vectors
        */
       if (err==0)
@@ -2962,7 +2962,7 @@ static void decl_const(int vclass)
     check_tagmismatch(tag,exprtag,FALSE,symbolline);
     sym=add_constant(constname,val,vclass,tag);
     if (sym!=NULL)
-      sc_attachdocumentation(sym);/* attach any documenation to the constant */
+      sc_attachdocumentation(sym);/* attach any documentation to the constant */
   } while (matchtoken(',')); /* enddo */   /* more? */
   needtoken(tTERM);
 }
@@ -3171,7 +3171,7 @@ static void decl_enum(int vclass,int fstatic)
     /* assign the constant list */
     assert(enumroot!=NULL);
     enumsym->dim.enumlist=enumroot;
-    sc_attachdocumentation(enumsym);  /* attach any documenation to the enumeration */
+    sc_attachdocumentation(enumsym);  /* attach any documentation to the enumeration */
   } /* if */
 }
 
@@ -3782,7 +3782,7 @@ static void funcstub(int fnative)
 
   declargs(sym,FALSE);
   /* "declargs()" found the ")" */
-  sc_attachdocumentation(sym);  /* attach any documenation to the function */
+  sc_attachdocumentation(sym);  /* attach any documentation to the function */
   if (!operatoradjust(opertok,sym,symbolname,tag))
     sym->usage &= ~uDEFINE;
   if (fpublic && opertok!=0) {
@@ -4046,7 +4046,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   } /* if */
   endfunc();
   sym->codeaddr=code_idx;
-  sc_attachdocumentation(sym);  /* attach collected documenation to the function */
+  sc_attachdocumentation(sym);  /* attach collected documentation to the function */
   if (litidx) {                 /* if there are literals defined */
     glb_declared+=litidx;
     begdseg();                  /* flip to DATA segment */
@@ -4155,12 +4155,12 @@ static int declargs(symbol *sym,int chkshadow)
   if ((sym->usage & uPROTOTYPED)!=0)
     while (sym->dim.arglist[oldargcnt].ident!=0)
       oldargcnt++;
-  argcnt=0;                             /* zero aruments up to now */
+  argcnt=0;                             /* zero arguments up to now */
   ident=iVARIABLE;
   numtags=0;
   fconst=fpragma=FALSE;
   fpublic= (sym->usage & uPUBLIC)!=0;
-  /* the '(' parantheses has already been parsed */
+  /* the '(' parentheses has already been parsed */
   if (!matchtoken(')')){
     do {                                /* there are arguments; process them */
       /* any legal name increases argument count (and stack offset) */
@@ -4383,7 +4383,7 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
         arg->hasdefault=TRUE;   /* argument has default value */
         arg->defvalue.array.size=litidx;
         arg->defvalue.array.addr=-1;
-        /* calulate size to reserve on the heap */
+        /* calculate size to reserve on the heap */
         arg->defvalue.array.arraysize=1;
         for (i=0; i<arg->numdim; i++)
           arg->defvalue.array.arraysize*=arg->dim[i];
@@ -4403,12 +4403,12 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
       if (size_tag_token!=0) {
         char* symname;
         cell val;
-        int paranthese;
+        int parentheses;
         if (ident==iREFERENCE)
           error(66,name);       /* argument may not be a reference */
-        paranthese=0;
+        parentheses=0;
         while (matchtoken('('))
-          paranthese++;
+          parentheses++;
         if (size_tag_token==uTAGOF && matchtoken(tLABEL)) {
           constvalue *tagsym;
           tokeninfo(&val,&symname);
@@ -4434,7 +4434,7 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
            * will trigger a fatal error because of too many error messages on one line */
           lexclr(FALSE);
         } /* if */
-        while (paranthese--)
+        while (parentheses--)
           needtoken(')');
       } else {
         constexpr(&arg->defvalue.val,&arg->defvalue_tag,NULL);
@@ -5217,7 +5217,7 @@ static void destructsymbols(symbol *root,int level)
           if ((opsym->usage & uPROTOTYPED)==0)
             error(71,symname);          /* operator must be declared before use */
         } /* if */
-        /* save PRI, in case of a return statment */
+        /* save PRI, in case of a return statement */
         if (!savepri) {
           pushreg(sPRI);        /* right-hand operand is in PRI */
           savepri=TRUE;
@@ -5372,7 +5372,7 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag)
 
   /* Test whether a global or local symbol with the same name exists. Since
    * constants are stored in the symbols table, this also finds previously
-   * defind constants. */
+   * defined constants. */
   sym=findglb(name,sSTATEVAR);
   if (sym==NULL)
     sym=findloc(name);
@@ -5447,7 +5447,7 @@ SC_FUNC symbol *add_builtin_string_constant(char *name,const char *val,
 
   /* Test whether a global or local symbol with the same name exists. Since
    * constants are stored in the symbols table, this also finds previously
-   * defind constants. */
+   * defined constants. */
   sym=findglb(name,sSTATEVAR);
   if (sym==NULL)
     sym=findloc(name);
@@ -5791,7 +5791,7 @@ SC_FUNC int constexpr(cell *val,int *tag,symbol **symptr)
  *  In the case a "simple assignment" operator ("=") is used within a test,
  *  the warning "possibly unintended assignment" is displayed. This routine
  *  sets the global variable "sc_intest" to true, it is restored upon termination.
- *  In the case the assignment was intended, use parantheses around the
+ *  In the case the assignment was intended, use parentheses around the
  *  expression to avoid the warning; primary() sets "sc_intest" to 0.
  *
  *  Global references: sc_intest (altered, but restored upon termination)
@@ -6029,7 +6029,7 @@ static int dofor(void)
   setline(TRUE);
   /* Expressions 2 and 3 are reversed in the generated code: expression 3
    * precedes expression 2. When parsing, the code is buffered and marks for
-   * the start of each expression are insterted in the buffer.
+   * the start of each expression are inserted in the buffer.
    */
   assert(!staging);
   stgset(TRUE);                     /* start staging */
@@ -6273,7 +6273,7 @@ static int doswitch(void)
   } /* if */
 
   #if !defined NDEBUG
-    /* verify that the case table is sorted (unfortunatly, duplicates can
+    /* verify that the case table is sorted (unfortunately, duplicates can
      * occur; there really shouldn't be duplicate cases, but the compiler
      * may not crash or drop into an assertion for a user error). */
     for (cse=caselist.first; cse!=NULL && cse->next!=NULL; cse=cse->next)
@@ -7837,7 +7837,7 @@ SC_FUNC void emit_parse_line(void)
 
   #if !defined NDEBUG
     /* verify that the opcode list is sorted (skip entry 1; it is reserved
-     * for a non-existant opcode)
+     * for a non-existent opcode)
      */
     { /* local */
       static int sorted=FALSE;
@@ -7986,7 +7986,7 @@ static void doreturn(void)
                 sub=finddepend(sub);
                 assert(sym!=NULL && sub!=NULL);
                 /* ^^^ both arrays have the same dimensions (this was checked
-                 *     earlier) so the dependend should always be found
+                 *     earlier) so the dependent should always be found
                  */
               } /* if */
             } /* for */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1820,7 +1820,7 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
             e=skippgroup(e);
           if (*e!='\0')
             e++;      /* skip non-alphapetic character (or closing quote of
-                       * a string, or the closing paranthese of a group) */
+                       * a string, or the closing parenthesis of a group) */
         } /* while */
         /* store the parameter (overrule any earlier) */
         free(args[arg]);
@@ -1958,7 +1958,7 @@ static void substallpatterns(unsigned char *line,int buffersize)
     /* if matching the operator "defined", skip it plus the symbol behind it */
     if (strncmp((char*)start,"defined",7)==0 && *(start+7)<=' ') {
       start+=7;         /* skip "defined" */
-      /* skip white space & parantheses */
+      /* skip white space & parentheses */
       while ((*start<=' ' && *start!='\0') || *start=='(')
         start++;
       /* skip the symbol behind it */
@@ -2701,7 +2701,7 @@ SC_FUNC void litinsert(cell value,int pos)
  *  Return current literal character and increase the pointer to point
  *  just behind this literal character.
  *
- *  Note: standard "escape sequences" are suported, but the backslash may be
+ *  Note: standard "escape sequences" are supported, but the backslash may be
  *        replaced by another character; the syntax '\ddd' is supported,
  *        but ddd must be decimal!
  */
@@ -3567,7 +3567,7 @@ SC_FUNC symbol *addvariable(const char *name,cell addr,int ident,int vclass,int 
 
 /*  getlabel
  *
- *  Returns te next internal label number. The global variable sc_labnum is
+ *  Returns the next internal label number. The global variable sc_labnum is
  *  initialized to zero.
  */
 SC_FUNC int getlabel(void)

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1,4 +1,4 @@
-/*  Pawn compiler - Recursive descend expresion parser
+/*  Pawn compiler - Recursive descend expression parser
  *
  *  Copyright (c) ITB CompuPhase, 1997-2005
  *
@@ -96,7 +96,7 @@ static void user_dec(void) {}
  *  no operator is found, nextop() returns 0.
  *
  *  If an operator is found in the expression, it cannot be used in a function
- *  call with omitted parantheses. Mark this...
+ *  call with omitted parentheses. Mark this...
  *
  *  Global references: sc_allowproccall   (modified)
  */
@@ -195,7 +195,7 @@ static void (*unopers[])(void) = { lneg, neg, user_inc, user_dec };
   if (oper==NULL)
     pc_ovlassignment=TRUE;
 
-  /* check existance and the proper declaration of this function */
+  /* check existence and the proper declaration of this function */
   if ((sym->usage & uMISSING)!=0 || (sym->usage & uPROTOTYPED)==0) {
     char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
     funcdisplayname(symname,sym->name);
@@ -234,8 +234,7 @@ static void (*unopers[])(void) = { lneg, neg, user_inc, user_dec };
     pushreg(sPRI);              /* right-hand operand is in PRI */
   } else if (savealt) {
     /* for the assignment operator, ALT may contain an address at which the
-     * result must be stored; this address must be preserved accross the
-     * call
+     * result must be stored; this address must be preserved across the call
      */
     assert(lval!=NULL);         /* this was checked earlier */
     assert(lval->ident==iARRAYCELL || lval->ident==iARRAYCHAR); /* checked earlier */
@@ -842,7 +841,7 @@ static cell array_levelsize(symbol *sym,int level)
  *
  *  Lowest hierarchy level (except for the , operator).
  *
- *  Global references: sc_intest        (reffered to only)
+ *  Global references: sc_intest        (referred to only)
  *                     sc_allowproccall (modified)
  */
 static int hier14(value *lval1)
@@ -929,7 +928,7 @@ static int hier14(value *lval1)
   } else if (lval1->ident==iARRAY || lval1->ident==iREFARRAY) {
     /* array assignment is permitted too (with restrictions) */
     if (oper)
-      return error(23); /* array assignment must be simple assigment */
+      return error(23); /* array assignment must be simple assignment */
     assert(lval1->sym!=NULL);
     if (array_totalsize(lval1->sym)==0)
       return error(46,lval1->sym->name);        /* unknown array size */
@@ -945,7 +944,7 @@ static int hier14(value *lval1)
     return error(22);           /* assignment to const argument */
   sc_allowproccall=FALSE;       /* may no longer use "procedure call" syntax */
 
-  lval3=*lval1;         /* save symbol to enable storage of expresion result */
+  lval3=*lval1;         /* save symbol to enable storage of expression result */
   lval1->arrayidx=org_arrayidx; /* restore array index pointer */
   if (lval1->ident==iARRAYCELL || lval1->ident==iARRAYCHAR
       || lval1->ident==iARRAY || lval1->ident==iREFARRAY)
@@ -1067,7 +1066,7 @@ static int hier14(value *lval1)
         sym2=finddepend(sym2);
         assert(sym1!=NULL && sym2!=NULL);
         /* ^^^ both arrays have the same dimensions (this was checked
-         *     earlier) so the dependend should always be found
+         *     earlier) so the dependent should always be found
          */
         if (sym1->dim.array.length!=sym2->dim.array.length)
           error(47);    /* array sizes must match */
@@ -2490,7 +2489,7 @@ static int nesting=0;
         close=!matchtoken(',');
         if (close) {              /* if not comma... */
           if (needtoken(tTERM)==1)/* ...must be end of statement */
-            lexpush();            /* push again, because end of statement is analised later */
+            lexpush();            /* push again, because end of statement is analyzed later */
         } /* if */
       } /* if */
     } while (!close && freading && !matchtoken(tENDEXPR)); /* do */

--- a/source/compiler/sc4.c
+++ b/source/compiler/sc4.c
@@ -37,7 +37,7 @@ static int fcurseg;     /* the file number (fcurrent) for the active segment */
 /* When a subroutine returns to address 0, the AMX must halt. In earlier
  * releases, the RET and RETN opcodes checked for the special case 0 address.
  * Today, the compiler simply generates a HALT instruction at address 0. So
- * a subroutine can savely return to 0, and then encounter a HALT.
+ * a subroutine can safely return to 0, and then encounter a HALT.
  */
 SC_FUNC void writeleader(symbol *root)
 {

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -233,9 +233,9 @@ static int errwarn;
  *  errors are ignored until lex() finds a semicolon or a keyword
  *  (lex() resets "errflag" in that case).
  *
- *  Global references: inpfname   (reffered to only)
- *                     fline      (reffered to only)
- *                     fcurrent   (reffered to only)
+ *  Global references: inpfname   (referred to only)
+ *                     fline      (referred to only)
+ *                     fcurrent   (referred to only)
  *                     errflag    (altered)
  */
 SC_FUNC int error(long number,...)

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -759,7 +759,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
 
   #if !defined NDEBUG
     /* verify that the opcode list is sorted (skip entry 1; it is reserved
-     * for a non-existant opcode)
+     * for a non-existent opcode)
      */
     assert(opcodelist[1].name!=NULL);
     for (i=2; i<arraysize(opcodelist); i++) {

--- a/source/compiler/sc7.c
+++ b/source/compiler/sc7.c
@@ -4,7 +4,7 @@
  *  ------------------
  *  The staging buffer allows buffered output of generated code, deletion
  *  of redundant code, optimization by a tinkering process and reversing
- *  the ouput of evaluated expressions (which is used for the reversed
+ *  the output of evaluated expressions (which is used for the reversed
  *  evaluation of arguments in functions).
  *  Initially, stgwrite() writes to the file directly, but after a call to
  *  stgset(TRUE), output is redirected to the buffer. After a call to
@@ -163,7 +163,7 @@ static SEQUENCE sequences[] = {
    *    push.pri                -
    *    load.s.pri n1           -
    *    pop.alt                 -
-   * The above also accurs for "load.pri" and for "const.pri",
+   * The above also occurs for "load.pri" and for "const.pri",
    * so add another two cases.
    */
   {
@@ -597,7 +597,7 @@ static SEQUENCE sequences[] = {
    *    load.s.pri n1           load.s.pri n1
    *    pop.alt                 -
    *
-   * The above also accurs for "load.pri" and for "const.pri",
+   * The above also occurs for "load.pri" and for "const.pri",
    * so add another two cases.
    */
   {
@@ -1459,7 +1459,7 @@ typedef struct {
  *  by '[', sENDREORDER by ']' and sEXPRSTART by '|' the following applies:
  *     '[]...'     valid, but useless; no output
  *     '[|...]     valid, but useless; only one string
- *     '[|...|...] valid and usefull
+ *     '[|...|...] valid and useful
  *     '[...|...]  invalid, first string doesn't start with '|'
  *     '[|...|]    invalid
  */
@@ -1530,7 +1530,7 @@ static int stgstring(char *start,char *end)
  *  Scraps code from the staging buffer by resetting "stgidx" to "index".
  *
  *  Global references: stgidx (altered)
- *                     staging (reffered to only)
+ *                     staging (referred to only)
  */
 SC_FUNC void stgdel(int index,cell code_index)
 {

--- a/source/compiler/sci18n.c
+++ b/source/compiler/sci18n.c
@@ -104,7 +104,7 @@ static int cp_readline(FILE *fp,char *string,size_t size)
 /* cp_path() sets the directory where all codepage files must be found (if
  * the parameter to cp_set() specifies a full path, that is used instead).
  * The path is specified into two parts: root and directory; the full path
- * for the codepage direcory is just the concatenation of the two, with a
+ * for the codepage directory is just the concatenation of the two, with a
  * directory separator in between. The directory is given in two parts,
  * because often a program already retrieves its "home" directory and the
  * codepages are most conveniently stored in a subdirectory of this home
@@ -328,7 +328,7 @@ SC_FUNC cell get_utf8_char(const unsigned char *string,const unsigned char **end
       if (--follow==0) {
         /* encoding a character in more bytes than is strictly needed,
          * is not really valid UTF-8; we are strict here to increase
-         * the chance of heuristic dectection of non-UTF-8 text
+         * the chance of heuristic detection of non-UTF-8 text
          * (JAVA writes zero bytes as a 2-byte code UTF-8, which is invalid)
          */
         if (result<lowmark)

--- a/source/compiler/tests/multiline_strings.pwn
+++ b/source/compiler/tests/multiline_strings.pwn
@@ -2,7 +2,7 @@ main()
 {
     // One line.
 	new str1[64] = "hello";
-    // Mutli line.
+    // Multi line.
 	new str2[64] = "
 hello
 world


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes typos that were found by using the codespell tool.
Used commands:
```
python3 -m pip install codespell
codespell --ignore-words-list="tenative" --quiet-level=2
```
Note that I added "tenative" to the exception list, as otherwise codespell would suggest "tentative" for every occurence of `teNATIVE`.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [x] Other

**Additional Documentation**: