### PR TITLE
Fix invalid code generation for variadic array cell arguments

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2338,7 +2338,7 @@ static int nesting=0;
               nest_stkusage++;
             } /* if */
           } else if (lval.ident==iCONSTEXPR || lval.ident==iEXPRESSION
-                     || lval.ident==iARRAYCHAR)
+                     || (lval.ident==iARRAYCELL && !lvalue) || lval.ident==iARRAYCHAR)
           {
             /* fetch value if needed */
             if (lval.ident==iARRAYCHAR)

--- a/source/compiler/tests/gh_642.meta
+++ b/source/compiler/tests/gh_642.meta
@@ -1,0 +1,47 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  const.pri 00000000
+[0-9a-f]+  const.alt 00000004
+[0-9a-f]+  add
+[0-9a-f]+  push.pri
+[0-9a-f]+  const.pri [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  sysreq.c [0-9a-f]+
+[0-9a-f]+  stack 0000000c
+[0-9a-f]+  const.pri 00000000
+[0-9a-f]+  const.alt 00000004
+[0-9a-f]+  add
+[0-9a-f]+  inc.i
+[0-9a-f]+  load.i
+[0-9a-f]+  heap 00000004
+[0-9a-f]+  stor.i
+[0-9a-f]+  move.pri
+[0-9a-f]+  push.pri
+[0-9a-f]+  const.pri [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  sysreq.c [0-9a-f]+
+[0-9a-f]+  stack 0000000c
+[0-9a-f]+  heap fffffffc
+[0-9a-f]+  const.pri 00000000
+[0-9a-f]+  const.alt 00000004
+[0-9a-f]+  add
+[0-9a-f]+  push.pri
+[0-9a-f]+  load.i
+[0-9a-f]+  swap.pri
+[0-9a-f]+  dec.i
+[0-9a-f]+  pop.pri
+[0-9a-f]+  heap 00000004
+[0-9a-f]+  stor.i
+[0-9a-f]+  move.pri
+[0-9a-f]+  push.pri
+[0-9a-f]+  const.pri [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  sysreq.c [0-9a-f]+
+[0-9a-f]+  stack 0000000c
+[0-9a-f]+  heap fffffffc
+"""
+}

--- a/source/compiler/tests/gh_642.pwn
+++ b/source/compiler/tests/gh_642.pwn
@@ -1,0 +1,11 @@
+#pragma option -O0
+#include <console>
+
+new arr[2] = { 0, 0 };
+
+main()
+{
+	printf("%d", arr[1]);
+	printf("%d", ++arr[1]);
+	printf("%d", arr[1]--);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes code generation for passing variadic function arguments of type "array cell" modified with `++` or `--` (see https://github.com/pawn-lang/compiler/issues/642#issuecomment-821991775).

**Which issue(s) this PR fixes**:

Fixes #642

**What kind of pull this is**:
* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
