### PR TITLE
Fix build errors on Linux and OS X

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -8545,7 +8545,7 @@ static void dopragma(void)
     str=parsestringparam(FALSE,&bck_litidx);
     if (str==NULL)
       continue;
-    
+
     /* split the option name from parameters */
     for (i=0; str[i]!='\0' && str[i]!=' '; i++)
       /* nothing */;

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -2588,7 +2588,7 @@ SC_FUNC void recstart(void)
  * Stops recording tokens.
  */
 SC_FUNC void recstop(void)
-{ 
+{
   if (sc_status!=statWRITE)
     return;
 

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -548,7 +548,7 @@ static int plnge1(int (*hier)(value *lval),value *lval)
 {
   int lvalue,org_index;
   cell org_cidx;
-  
+
   org_index=lval_stgidx;
   org_cidx=lval_cidx;
   stgget(&lval_stgidx,&lval_cidx);  /* mark position in code generator */
@@ -571,7 +571,7 @@ static void plnge2(void (*oper)(void),
 {
   int org_index;
   cell org_cidx;
-  
+
   org_index=lval_stgidx;
   org_cidx=lval_cidx;
   stgget(&lval_stgidx,&lval_cidx);  /* mark position in code generator */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -650,11 +650,11 @@ static void plnge2(void (*oper)(void),
     } else {
       if (lval1->tag==BOOLTAG && lval2->tag==BOOLTAG
           && oper!=ob_or && oper!=ob_xor && oper!=ob_and && oper!=ob_eq && oper!=ob_ne) {
-        static const void (*opers[])(void) = {
+        static void (*const opers[])(void) = {
           os_mult,os_div,os_mod,ob_add,ob_sub,ob_sal,
           os_sar,ou_sar,os_le,os_ge,os_lt,os_gt
         };
-        static const char* opnames[] = {
+        static const char *opnames[] = {
           "*","/","%","+","-","<<",
           ">>",">>>","<=",">=","<",">"
         };


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes build errors that originate from an incorrect declaration of an array of function pointers (initially I declared it as `static const void (*opers[])(void)` while I should have used `static void (*const opers[])(void)` - this was no problem for MSVC and MinGW, but caused errors when building for Linux and OS X with GCC/Clang).
Also removed a few excess trailing whitespaces while I was at it.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [x] Other

**Additional Documentation**:
