### PR TITLE
Fix assertions for native functions returning arrays

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -3224,12 +3224,18 @@ SC_FUNC void delete_symbols(symbol *root,int level,int delete_labels,int delete_
        * this only if "globals" must be deleted; other iREFARRAY instances
        * (locals) are also deleted
        */
-      mustdelete=delete_functions;
+      mustdelete=(sym->vclass==sGLOBAL) ? delete_functions : TRUE;
       for (parent_sym=sym->parent; parent_sym!=NULL && parent_sym->ident!=iFUNCTN; parent_sym=parent_sym->parent)
         assert(parent_sym->ident==iREFARRAY);
       assert(parent_sym==NULL || (parent_sym->ident==iFUNCTN && parent_sym->parent==NULL));
-      if (parent_sym==NULL || parent_sym->ident!=iFUNCTN)
-        mustdelete=TRUE;
+      if (sym->vclass==sGLOBAL) {
+        assert(parent_sym!=NULL && parent_sym->ident==iFUNCTN);
+        if ((parent_sym->usage & uNATIVE)!=0) {
+          /* native functions aren't preserved (see the comment under the
+           * 'iFUNCTN' case below), so the array must be deleted as well */
+          mustdelete=TRUE;
+        } /* if */
+      } /* if */
       break;
     case iCONSTEXPR:
       /* delete constants (predefined constants are checked later) */

--- a/source/compiler/tests/gh_466.meta
+++ b/source/compiler/tests/gh_466.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+"""
+}

--- a/source/compiler/tests/gh_466.pwn
+++ b/source/compiler/tests/gh_466.pwn
@@ -1,0 +1,16 @@
+forward [2][3]Func();
+Func()
+{
+	new a[2][3];
+	return a;
+}
+
+native [2][3]NativeFunc();
+
+main()
+{
+	new a[2][3];
+	a = Func();
+	a = NativeFunc();
+	return a[0][0];
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two assertions triggering when a native function explicitly returning an array gets defined or called (see #466).

**Which issue(s) this PR fixes**:

Fixes #466

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

Special thanks to @IllidanS4 not only for reporting the bug this PR fixes, but also for making a thorough research for the source of the said bug, which made the overall process of fixing it much easier.