### PR TITLE
`const static` for declaring static constants

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3011,8 +3011,10 @@ static void decl_const(int vclass)
   char *str;
   int tag,exprtag;
   int symbolline;
+  int fstatic;
   symbol *sym;
 
+  fstatic=(vclass==sGLOBAL && matchtoken(tSTATIC));
   insert_docstring_separator();         /* see comment in newfunc() */
   do {
     tag=pc_addtag(NULL);
@@ -3025,8 +3027,11 @@ static void decl_const(int vclass)
     /* add_constant() checks for duplicate definitions */
     check_tagmismatch(tag,exprtag,FALSE,symbolline);
     sym=add_constant(constname,val,vclass,tag);
-    if (sym!=NULL)
+    if (sym!=NULL) {
+      if (fstatic)
+        sym->fnumber=fcurrent;
       sc_attachdocumentation(sym);/* attach any documentation to the constant */
+    } /* if */
   } while (matchtoken(',')); /* enddo */   /* more? */
   needtoken(tTERM);
 }

--- a/source/compiler/tests/const_static.inc
+++ b/source/compiler/tests/const_static.inc
@@ -1,0 +1,6 @@
+const static const_val = 0;
+
+PrintConstVal()
+{
+	printf("%d", const_val);
+}

--- a/source/compiler/tests/const_static.inc
+++ b/source/compiler/tests/const_static.inc
@@ -1,6 +1,8 @@
-const static const_val = 0;
+const static const_val = 2;
 
-PrintConstVal()
+UseConstVal()
 {
+	new a[const_val] = { 0, 1 };
+	#pragma unused a
 	printf("%d", const_val);
 }

--- a/source/compiler/tests/const_static.meta
+++ b/source/compiler/tests/const_static.meta
@@ -1,0 +1,9 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+const_static.pwn(7) : error 017: undefined symbol "const_val"
+const_static.pwn(10) : error 020: invalid symbol name ""
+const_static.pwn(10) : warning 215: expression has no effect
+const_static.pwn(10) : warning 203: symbol is never used: ""
+"""
+}

--- a/source/compiler/tests/const_static.pwn
+++ b/source/compiler/tests/const_static.pwn
@@ -1,0 +1,13 @@
+#include <console>
+#include "const_static.inc"
+
+main()
+{
+	PrintConstVal();
+	printf("%d", const_val); // error 017: undefined symbol "const_val"
+
+	// A combination of "const static" can't be used for local constants.
+	const static local_const = 0; // error 020: invalid symbol name ""
+	                              // warning 215: expression has no effect
+	                              // warning 203: symbol is never used: ""
+}

--- a/source/compiler/tests/const_static.pwn
+++ b/source/compiler/tests/const_static.pwn
@@ -3,7 +3,7 @@
 
 main()
 {
-	PrintConstVal();
+	UseConstVal();
 	printf("%d", const_val); // error 017: undefined symbol "const_val"
 
 	// A combination of "const static" can't be used for local constants.


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a combination of `const static` for declaring constants limited to the scope of the current source file. This combination is only valid for global constants, it's not allowed for locals.

**Which issue(s) this PR fixes**:

Fixes #70

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: