### PR TITLE
Fix sampctl link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ seems to be based on an older release of Pawn.
 [artifacts]:
   https://ci.appveyor.com/project/Southclaws/compiler/branch/master/artifacts
 [compat]: https://github.com/pawn-lang/compiler/wiki/Compatibility-mode
-[sampctl]: http://bit.ly/sampctl
+[sampctl]: https://github.com/Southclaws/sampctl
 [contributing]:
   https://github.com/pawn-lang/compiler/tree/master/.github/CONTRIBUTING.md
 [build_source]: https://github.com/pawn-lang/compiler/wiki/Building-From-Source


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

This PR replaces the old sampctl link (in this case a bit.ly link redirecting to sampctl.com) in the readme, with the GitHub repo link. sampctl.com is no longer owned by the author and currently displays a monetised parking website that often redirects to a phishing website disguised as a local newspaper website (at least here in CH).

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

None

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [ ] A New Feature
* [x] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
