### PR TITLE
Fix crash from an incomplete `do-while` statement

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5972,6 +5972,7 @@ static int test(int label,int parens,int invert)
   cell cidx;
   int ident,tag;
   int endtok;
+  short save_intest;
   cell constval;
   symbol *sym;
   int localstaging=FALSE;
@@ -5985,7 +5986,7 @@ static int test(int label,int parens,int invert)
     #endif
   } /* if */
 
-  PUSHSTK_I(sc_intest);
+  save_intest=sc_intest;
   sc_intest=TRUE;
   endtok=0;
   if (parens!=TEST_PLAIN) {
@@ -6039,7 +6040,7 @@ static int test(int label,int parens,int invert)
   else
     jmp_eq0(label);             /* jump to label if false (equal to 0) */
   markexpr(sEXPR,NULL,0);       /* end expression (give optimizer a chance) */
-  sc_intest=(short)POPSTK_I();  /* double typecast to avoid warning with Microsoft C */
+  sc_intest=save_intest;
   if (localstaging) {
     stgout(0);                  /* output queue from the very beginning (see
                                  * assert() when localstaging is set to TRUE) */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -6017,7 +6017,7 @@ static int test(int label,int parens,int invert)
   } /* if */
   if (ident==iCONSTEXPR) {      /* constant expression */
     int testtype=0;
-    sc_intest=(short)POPSTK_I();/* restore stack */
+    sc_intest=save_intest;      /* restore stack */
     stgdel(index,cidx);
     if (constval) {             /* code always executed */
       error(206);               /* redundant test: always non-zero */

--- a/source/compiler/tests/incomplete_dowhile_crash.meta
+++ b/source/compiler/tests/incomplete_dowhile_crash.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+incomplete_dowhile_crash.pwn(6) : error 001: expected token: "while", but found "}"
+incomplete_dowhile_crash.pwn(7) : error 001: expected token: ";", but found "-end of file-"
+"""
+}

--- a/source/compiler/tests/incomplete_dowhile_crash.pwn
+++ b/source/compiler/tests/incomplete_dowhile_crash.pwn
@@ -1,0 +1,6 @@
+#pragma option -;+
+
+main()
+{
+	do {}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the compiler crash from an incomplete `do-while` statement without the `while (...);` part (see #678).
Function `test()` (file `sc1.c`) was saving and restoring the previous value of `sc_intest` through `PUSHSTK_I()/POPSTK_I()`, and this was preventing the compiler from stopping the compilation process when the end of file was reached before closing the `do-while` statement. Making the function save/restore the value of `sc_intest` using the *actual stack* (by saving the value into a local variable) fixes the issue.

**Which issue(s) this PR fixes**:

Fixes #678

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: