### PR TITLE
Use GitHub-flavored Markdown to highlight the MCVE code in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,7 +25,7 @@ Learn more about writing MCVE from [StackOverflow](https://stackoverflow.com/hel
 If this section is not relevant, feel free to remove this section from your issue.
 -->
 
-```
+```Pawn
 ```
 
 <!-- comments on the code, if any -->


### PR DESCRIPTION
**What this PR does / why we need it**:

This simple tweak makes GitHub properly highlight the MCVE code in bug reports, thus making it easier to read. Since usually MCVEs are supposed to be Pawn code, I'm sure there should be no reason not to highlight them as Pawn.

**Which issue(s) this PR fixes**:

Fixes #

**What kind of pull this is**:

* [ ] A Bug Fix
* [ ] A New Feature
* [x] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
