### PR TITLE
Fix explicit zero array size being treated as no size

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2982,7 +2982,7 @@ static cell needsub(int *tag,constvalue_root **enumroot)
     return 0;               /* zero size (like "char msg[]") */
 
   constexpr(&val,tag,&sym); /* get value (must be constant expression) */
-  if (val<0) {
+  if (val<=0) {
     error(9);               /* negative array size is invalid; assumed zero */
     val=0;
   } /* if */

--- a/source/compiler/tests/gh_668.meta
+++ b/source/compiler/tests/gh_668.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_668.pwn(1) : error 009: invalid array size (negative, zero or out of bounds)
+gh_668.pwn(5) : error 009: invalid array size (negative, zero or out of bounds)
+  """
+}

--- a/source/compiler/tests/gh_668.pwn
+++ b/source/compiler/tests/gh_668.pwn
@@ -1,0 +1,7 @@
+new global_array[0] = { 0 }; // error 009
+
+main()
+{
+	new local_array[0] = { 0 }; // error 009
+	return global_array[0] + local_array[0];
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug with the compiler mistreating `new array[0] = { ... };` as `new array[] = { ... };` (see #668).

**Which issue(s) this PR fixes**:

Fixes #668

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
