### PR TITLE
Fix return array size specifications being ignored in operator declarations

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3822,8 +3822,10 @@ static void funcstub(int fnative)
   } /* if */
 
   if (tok==tOPERATOR) {
-    if (numdim!=0)
+    if (numdim!=0) {
       error(10);                /* invalid function or declaration */
+      numdim=0;                 /* ignore the array size specification */
+    } /* if */
     opertok=operatorname(symbolname);
     if (opertok==0)
       return;                   /* error message already given */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3925,7 +3925,7 @@ static void funcstub(int fnative)
       if (numdim!=sym->child->dim.array.level+1) {
         error(25);              /* function heading differs from prototype */
       } else {
-        unsigned int i=0;
+        int i=0;
         sub=sym->child;
         do {
           if (dim[i]!=sub->dim.array.length) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes return array size specifications being silently ignored in new-style operator declarations (see #685) and makes the compiler treat such specifications as errors.

**Which issue(s) this PR fixes**:

Fixes #685

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
