### PR TITLE
cmake size configuration

### DIFF
--- a/source/compiler/CMakeLists.txt
+++ b/source/compiler/CMakeLists.txt
@@ -1,6 +1,11 @@
 project(pawnc C)
 cmake_minimum_required(VERSION 2.8)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+set(sNAMEMAX 31 CACHE INT "The maximum length of function/symbol names")
+set(PAWN_CELL_SIZE 32 CACHE INT "The number of bits in a cell")
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
 set(VERSION_MAJOR 3)
@@ -61,6 +66,8 @@ endif()
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
 endif()
+
+add_definitions(-DsNAMEMAX=${sNAMEMAX} -DPAWN_CELL_SIZE=${PAWN_CELL_SIZE})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/version.h)
@@ -174,6 +181,7 @@ if(BUILD_TESTING)
     ../amx/amxaux.h
     ../amx/amxcons.c
     ../amx/amxcore.c
+    ../amx/amxstring.c
   )
   if(UNIX)
     set(PAWNRUNS_SRCS


### PR DESCRIPTION
Some cmake options back-ported from open.mp, plus `-DsNAMEMAX` and `-DPAWN_CELL_SIZE`.

<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

To pass sizes on the command line.

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

Fixes #

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
