### PR TITLE
cmake: fix macOS library linking

### DIFF
--- a/source/compiler/CMakeLists.txt
+++ b/source/compiler/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

- Fix pawncc execute error `Library not loaded` after `make install`

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

Fixes #297

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

fix: 
`dyld[48557]: Library not loaded: @rpath/libpawnc.dylib`

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
